### PR TITLE
Bugfixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_toolchain: [nightly, nightly-2022-03-01]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -24,11 +27,11 @@ jobs:
         shell: bash
         run: msp430-elf-gcc --version
 
-      - name: Install nightly toolchain
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.rust_toolchain }}
           override: true
           components: rust-src
 

--- a/examples/capture_intr.rs
+++ b/examples/capture_intr.rs
@@ -1,6 +1,7 @@
 #![no_main]
 #![no_std]
 #![feature(abi_msp430_interrupt)]
+#![feature(let_else)]
 
 // This example also demonstrates how to write panic-free code using panic_never.
 

--- a/examples/gpio_interrupts.rs
+++ b/examples/gpio_interrupts.rs
@@ -1,6 +1,7 @@
 #![no_main]
 #![no_std]
 #![feature(abi_msp430_interrupt)]
+#![feature(let_else)]
 
 use critical_section::with;
 use msp430fr2355::interrupt;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -19,13 +19,25 @@ impl Delay {
     }
 }
 
-impl DelayMs<u16> for Delay {
-    #[inline]
-    fn delay_ms(&mut self, ms: u16) {
-        for _ in 0..ms {
-            for _ in 0..self.nops_per_ms {
-                asm::nop();
+macro_rules! impl_delay {
+    ($typ: ty) => {
+        impl DelayMs<$typ> for Delay {
+            #[inline]
+            fn delay_ms(&mut self, ms: $typ) {
+                for _ in 0..ms {
+                    for _ in 0..self.nops_per_ms {
+                        asm::nop();
+                    }
+                }
             }
         }
-    }
+    };
 }
+
+impl_delay!(u8);
+impl_delay!(u16);
+impl_delay!(u32);
+
+// A delay implementation for the default literal type to allow calls like `delay_ms(100)`
+// Negative durations are treated as zero.
+impl_delay!(i32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,15 @@
 #![allow(incomplete_features)] // Enable specialization without warnings
 #![feature(specialization)]
 #![feature(asm_experimental_arch)]
-#![deny(missing_docs)]
+
+#![allow(stable_features)] // Feature flags used on older compiler versions
+#![feature(derive_default_enum)]
+#![feature(exclusive_range_pattern)]
+#![feature(const_option)]
+#![feature(nonzero_ops)]
 #![feature(asm_const)]
+
+#![deny(missing_docs)]
 
 pub mod adc;
 pub mod batch_gpio;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -526,6 +526,7 @@ impl<USCI: SerialUsci> Rx<USCI> {
 }
 
 /// Serial receive errors
+#[derive(Clone, Copy, Debug)]
 pub enum RecvError {
     /// Framing error
     Framing,


### PR DESCRIPTION
A much smaller PR this time. I've noticed a couple pain points since the previous version: 

- A few feature flags were missing which prevented using older compiler versions. I've tested back to 2022-03-01 (v1.61), anything older runs afoul of the `msp430` crate and not us. 
- `RecvError` was missing `Debug`, which prevented unwrapping. `Copy` and `Clone` have also been added to bring parity with the I2C and SPI error types.
- Some external crates expect different implementations of `DelayMs` - sometimes u8, sometimes u32, which necessitated the user write a wrapper.
  - Because there are multiple implementations now we also need one for the default literal type, i32, to preserve the ability to call `delay_ms(100)` without having to disambiguate by suffixing the literal with `_u32` or `_u16` every time. Negative delays are treated as zero.

As usual, any comments or modifications welcome.