### PR TITLE
Reintroduces3 required nop's

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -288,6 +288,10 @@ impl<SMCLK: SmclkState> ClockConfig<MclkDefined, SMCLK> {
                     ._1()
             });
 
+            msp430::asm::nop();
+            msp430::asm::nop();
+            msp430::asm::nop();
+
             fll_on();
 
             while !self.periph.csctl7.read().fllunlock().is_fllunlock_0() {}


### PR DESCRIPTION
This PR reintroduces three NOP instructions immediately after configuring the DCO range and FLL parameters, as recommended in [slaa992](https://www.ti.com/lit/an/slaa992/slaa992.pdf), Section 3.

These NOPs were previously removed, but they are critical to allow time for the DCO settings to settle before re-enabling the FLL. Omitting them can cause unreliable FLL locking behavior.

Reference:

> "Execute NOP three times to allow time for the settings to be applied."

This fix aligns the implementation with TI’s recommended initialization sequence and improves system stability during startup.

Clarifies and addresses the intention in **#22** — only extra or redundant `nop`s were meant to be removed. This change reintroduces the documented and necessary three `nop`s for stable operation.