### PR TITLE
Add SPI Slave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased - 2025-XX-XX
 
+- Add SPI slave support. Modify SPI configuration and `SpiErr`.
+- Fix SPI flushing bug.
 - Add support for Smart Analog Combo and Enhanced Comparator modules (MSP430FR23xx only)
 - Add support for reading from / writing to backup memory and information memory
 - Add support for hardware CRC module

--- a/examples/spi_bus.rs
+++ b/examples/spi_bus.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
     // Multi-master mode allows another master to control whether this device's SCK 
     // and MOSI pins are outputs or high impedance via the STE pin.
     let mut spi = SpiConfig::new(periph.E_USCI_A0, MODE_0, true)
-        .as_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
+        .to_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
         .single_master_bus(miso, mosi, sck);
 
     loop {

--- a/examples/spi_bus.rs
+++ b/examples/spi_bus.rs
@@ -1,0 +1,73 @@
+#![no_main]
+#![no_std]
+
+// This example uses the SpiBus embedded-hal interface, with a software controlled CS pin.
+
+use embedded_hal::{digital::OutputPin, spi::MODE_0};
+use embedded_hal::delay::DelayNs;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv}, fram::Fram, gpio::Batch, pmm::Pmm, spi::SpiConfig, watchdog::Wdt
+};
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.FRCTL);
+    let _wdt = Wdt::constrain(periph.WDT_A);
+
+    let pmm = Pmm::new(periph.PMM);
+    let p1 = Batch::new(periph.P1)
+        .split(&pmm);
+    let mosi = p1.pin7.to_alternate1();
+    let miso = p1.pin6.to_alternate1();
+    let sck  = p1.pin5.to_alternate1();
+    let mut cs   = p1.pin4.to_output();
+    cs.set_high().ok();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.CS)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    // In single master mode SCK and MOSI are always outputs.
+    // Multi-master mode allows another master to control whether this device's SCK 
+    // and MOSI pins are outputs or high impedance via the STE pin.
+    let mut spi = SpiConfig::new(periph.E_USCI_A0, MODE_0, true)
+        .as_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
+        .single_master_bus(miso, mosi, sck);
+
+    loop {
+        // Blocking interface available through embedded-hal trait
+        use embedded_hal::spi::SpiBus;
+
+        // Perform the following transaction:
+        // Send: 0x12, 0x00,    0x00,    0x34,    0x56,
+        // Recv: N/A,  recv[0], recv[1], recv[2], N/A
+        let mut recv = [0; 3];
+        cs.set_low().ok();
+
+        // These methods do return errors, but because we haven't used the non-blocking  
+        // API (from embedded-hal-nb) or interrupts the Rx buffer should never overrun because  
+        // the blocking interface automatically reads after every write. 
+        spi.write(&[0x12]).unwrap();
+        spi.read(&mut recv[0..2]).unwrap();
+        spi.transfer(&mut recv[2..], &[0x34, 0x56]).unwrap();
+        
+        spi.flush().unwrap();
+        cs.set_high().ok();
+
+        delay.delay_ms(1000);
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/examples/spi_bus_nb.rs
+++ b/examples/spi_bus_nb.rs
@@ -36,8 +36,8 @@ fn main() -> ! {
         .freeze(&mut fram);
 
     let mut spi = SpiConfig::new(periph.E_USCI_A0, MODE_0, true)
-        .use_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
-        .configure(miso, mosi, sck);
+        .as_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
+        .single_master_bus(miso, mosi, sck);
 
     loop {
         cs.set_low().ok();

--- a/examples/spi_nb.rs
+++ b/examples/spi_nb.rs
@@ -3,7 +3,6 @@
 
 // This example uses the non-blocking interface from embedded-hal-nb, with a software controlled CS pin.
 
-use embedded_hal_nb::spi::FullDuplex;
 use embedded_hal::{digital::OutputPin, spi::MODE_0};
 use embedded_hal::delay::DelayNs;
 use msp430_rt::entry;
@@ -40,6 +39,9 @@ fn main() -> ! {
         .single_master_bus(miso, mosi, sck);
 
     loop {
+        // Non-blocking interface available through embedded-hal-nb
+        use embedded_hal_nb::spi::FullDuplex;
+
         cs.set_low().ok();
 
         // Blocking send. Sends out data on the MOSI line

--- a/examples/spi_nb.rs
+++ b/examples/spi_nb.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
         .freeze(&mut fram);
 
     let mut spi = SpiConfig::new(periph.E_USCI_A0, MODE_0, true)
-        .as_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
+        .to_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
         .single_master_bus(miso, mosi, sck);
 
     loop {

--- a/examples/spi_slave_interrupt.rs
+++ b/examples/spi_slave_interrupt.rs
@@ -66,12 +66,12 @@ fn main() -> ! {
     // there are other slaves on the bus. On an exclusive bus MISO is always an output.
     // On a shared bus the STE pin is used to control whether this slave's MISO is an output or high impedance pin.
     let mut spi_slave = SpiConfig::new(periph.E_USCI_A0, MODE_0, true)
-        .as_slave()
+        .to_slave()
         .shared_bus(sl_miso, sl_mosi, sl_sclk, sl_ste, StePolarity::EnabledWhenLow);
 
     // Configure another as an SPI master to drive the bus.
     let mut spi = SpiConfig::new(periph.E_USCI_B1, MODE_0, true)
-        .as_master_using_smclk(&smclk, 800) // 8MHz / 80 = 100kHz
+        .to_master_using_smclk(&smclk, 800) // 8MHz / 80 = 100kHz
         .single_master_bus(miso, mosi, sclk);
 
     critical_section::with(|cs| {

--- a/examples/spi_slave_interrupt.rs
+++ b/examples/spi_slave_interrupt.rs
@@ -1,0 +1,125 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+#![feature(let_else)]
+
+// This example demonstrates an SPI slave using interrupts. 
+// Another eUSCI peripheral is configured as an SPI master to drive the bus.
+// P6.6 (green LED) should turn on and stay on
+// P1.0 (red LED) should blink with each sent SPI transaction 
+
+// Connect:
+// P1.7 <--> P4.6, 
+// P1.6 <--> P4.7, 
+// P1.5 <--> P4.5,
+// P1.4 <--> P4.4
+
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use embedded_hal::digital::{OutputPin, StatefulOutputPin};
+use embedded_hal::spi::{SpiBus, MODE_0};
+use embedded_hal::delay::DelayNs;
+use msp430_rt::entry;
+use msp430fr2355::{interrupt, E_USCI_A0};
+use msp430fr2x5x_hal::spi::{SpiConfig, SpiErr, SpiSlave, StePolarity};
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv}, fram::Fram, gpio::Batch, pmm::Pmm, watchdog::Wdt
+};
+
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.FRCTL);
+    let _wdt = Wdt::constrain(periph.WDT_A);
+
+    let pmm = Pmm::new(periph.PMM);
+    let p1 = Batch::new(periph.P1)
+        .split(&pmm);
+    let sl_mosi = p1.pin7.to_alternate1();
+    let sl_miso = p1.pin6.to_alternate1();
+    let sl_sclk = p1.pin5.to_alternate1();
+    let sl_ste  = p1.pin4.to_alternate1();
+
+    let p4 = Batch::new(periph.P4)
+        .split(&pmm);
+    let mosi = p4.pin6.to_alternate1();
+    let miso = p4.pin7.to_alternate1();
+    let sclk = p4.pin5.to_alternate1();
+    let mut ste = p4.pin4.to_output();
+    ste.set_high().ok();
+
+    let mut red_led = p1.pin0.to_output();
+    let mut green_led = Batch::new(periph.P6).split(&pmm).pin6.to_output();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.CS)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    // Configure a peripheral as an SPI slave. 
+    // It can be configured for either a shared or exclusive bus depending on whether
+    // there are other slaves on the bus. On an exclusive bus MISO is always an output.
+    // On a shared bus the STE pin is used to control whether this slave's MISO is an output or high impedance pin.
+    let mut spi_slave = SpiConfig::new(periph.E_USCI_A0, MODE_0, true)
+        .as_slave()
+        .shared_bus(sl_miso, sl_mosi, sl_sclk, sl_ste, StePolarity::EnabledWhenLow);
+
+    // Configure another as an SPI master to drive the bus.
+    let mut spi = SpiConfig::new(periph.E_USCI_B1, MODE_0, true)
+        .as_master_using_smclk(&smclk, 800) // 8MHz / 80 = 100kHz
+        .single_master_bus(miso, mosi, sclk);
+
+    critical_section::with(|cs| {
+        spi_slave.set_rx_interrupt();
+        SPI_SLAVE.replace(cs, Some(spi_slave));
+    });
+
+    unsafe { msp430::interrupt::enable() };
+
+    loop {
+        let mut recv_buf = [0; 4];
+        let send_buf = [12, 14, 0xFF];
+        
+        ste.set_low().ok(); // Enable slave MISO
+        
+        // Can return Err, but both error types aren't relevant here.
+        let _ = spi.transfer(&mut recv_buf, &send_buf);
+        let _ = spi.flush();
+
+        ste.set_high().ok(); // Make slave MISO high impedance
+
+        // Green LED on if result matches expected
+        green_led.set_state( (recv_buf[1..] == [13, 15, 00]).into() ).ok();
+        red_led.toggle().ok();
+
+        delay.delay_ms(1000);
+    }
+}
+
+static SPI_SLAVE: Mutex<RefCell<Option< SpiSlave<E_USCI_A0> >>> = Mutex::new(RefCell::new(None));
+
+#[interrupt]
+fn EUSCI_A0() {
+    critical_section::with(|cs| {
+        let Some(ref mut spi_slave) = *SPI_SLAVE.borrow_ref_mut(cs) else {return};
+        // If you have multiple interrupts enabled you can use .interrupt_source() to determine which one caused this interrupt
+        let byte = match unsafe{spi_slave.read_unchecked()} { // Only Rx interrupts are enabled, so Rx buffer must be ready
+            Ok(b) => b,
+            Err(SpiErr::Overrun(b)) => b,
+        };
+        nb::block!( spi_slave.write(byte.wrapping_add(1)) ).unwrap(); // Infallible, safe to unwrap after blocking
+    });
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/src/hw_traits/eusci.rs
+++ b/src/hw_traits/eusci.rs
@@ -341,6 +341,8 @@ pub trait EusciSPI: Steal {
     fn overrun_flag(&self) -> bool;
 
     fn iv_rd(&self) -> u16;
+
+    fn is_busy(&self) -> bool;
 }
 
 pub trait UartUcxStatw {
@@ -355,7 +357,7 @@ pub trait SpiStatw {
     fn uclisten(&self) -> bool;
     fn ucfe(&self) -> bool;
     fn ucoe(&self) -> bool;
-    // fn ucbusy1(&self) -> bool;
+    fn ucbusy(&self) -> bool;
 }
 
 pub trait I2CUcbIfgOut {
@@ -483,6 +485,10 @@ macro_rules! eusci_impl {
             fn iv_rd(&self) -> u16 {
                 self.$ucxiv().read().uciv().bits()
             }
+
+            fn is_busy(&self) -> bool {
+                self.$ucxstatw().read().ucbusy()
+            }
         }
 
         impl SpiStatw for $StatwSpi {
@@ -501,10 +507,13 @@ macro_rules! eusci_impl {
                 self.ucoe().bit()
             }
 
-            // #[inline(always)]
-            // fn ucbusy1(&self) -> bool{
-            //     self.ucbusy().bit()
-            // }
+            #[inline(always)]
+            fn ucbusy(&self) -> bool{
+                // TODO: Update the PAC 
+                // The PAC is currently missing the UCBUSY bit in the SPI version of this register
+                const UCBUSY_MASK: u16 = (1<<0);
+                (self.bits() & UCBUSY_MASK) > 0
+            }
         }
     };
 }

--- a/src/hw_traits/eusci.rs
+++ b/src/hw_traits/eusci.rs
@@ -24,7 +24,7 @@ macro_rules! reg_struct {
         }
     ) => {
         $(#[$attr:meta])*
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, Default)]
         pub struct $struct_name {
             $($(pub $bool_name : bool, $(#[$f_attr])*)*)?
             $($(pub $val_name : $val_type , $(#[$e_attr])*)*)?
@@ -42,23 +42,28 @@ macro_rules! reg_struct {
     };
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum Ucssel {
     Uclk = 0,
     Aclk = 1,
+    #[default]
     Smclk = 2,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum Ucmode {
+    #[default]
     ThreePinSPI = 0,
+    /// 0b01
     FourPinSPI1 = 1,
+    /// 0b10
     FourPinSPI0 = 2,
     I2CMode = 3,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum Ucglit {
+    #[default]
     Max50ns = 0,
     Max25ns = 1,
     Max12_5ns = 2,
@@ -66,9 +71,10 @@ pub enum Ucglit {
 }
 
 /// Clock low timeout select
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum Ucclto {
     /// Disable clock low time-out counter
+    #[default]
     Ucclto00b = 0,
     /// 135000 MODCLK cycles (approximately 28 ms)
     Ucclto01b = 1,
@@ -80,10 +86,11 @@ pub enum Ucclto {
 
 /// Automatic STOP condition generation. In slave mode, only settings 00b and 01b
 /// are available.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum Ucastp {
     /// No automatic STOP generation. The STOP condition is generated after
     /// the user sets the UCTXSTP bit. The value in UCBxTBCNT is a don't care.
+    #[default]
     Ucastp00b = 0,
     /// UCBCNTIFG is set when the byte counter reaches the threshold defined in
     /// UCBxTBCNT

--- a/src/hw_traits/eusci.rs
+++ b/src/hw_traits/eusci.rs
@@ -326,6 +326,9 @@ pub trait EusciSPI: Steal {
 
     fn txbuf_wr(&self, val: u8);
 
+    fn ie_rd(&self) -> u16;
+    fn ie_wr(&self, reg: u16);
+
     fn set_transmit_interrupt(&self);
 
     fn clear_transmit_interrupt(&self);
@@ -428,6 +431,16 @@ macro_rules! eusci_impl {
             #[inline(always)]
             fn txbuf_wr(&self, val: u8) {
                 self.$ucxtxbuf().write(|w| unsafe { w.uctxbuf().bits(val) });
+            }
+
+            #[inline(always)]
+            fn ie_rd(&self) -> u16 {
+                self.$ucxie().read().bits()
+            }
+            
+            #[inline(always)]
+            fn ie_wr(&self, reg: u16) {
+                self.$ucxie().write(|w| unsafe{ w.bits(reg) })
             }
 
             #[inline(always)]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -407,9 +407,7 @@ mod ehal1 {
         }
     
         fn flush(&mut self) -> Result<(), Self::Error> {
-            // I would usually do this by checking the UCBUSY bit, but 
-            // it seems to be missing from the (SPI version of the) PAC...
-            while !self.usci.transmit_flag() {}
+            while self.usci.is_busy() {}
             Ok(())
         }
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -205,20 +205,20 @@ impl<USCI: SpiUsci> SpiConfig<USCI, RoleNotSet> {
         Self { usci, ctlw0, prescaler: 0, _phantom: PhantomData }
     }
     /// This device will act as a slave on the SPI bus.
-    pub fn as_slave(mut self) -> SpiConfig<USCI, Slave> {
+    pub fn to_slave(mut self) -> SpiConfig<USCI, Slave> {
         self.ctlw0.ucmst = false;
         // UCSSEL is 'don't care' in slave mode
         SpiConfig { usci: self.usci, prescaler: self.prescaler, ctlw0: self.ctlw0, _phantom: PhantomData }
     }
     /// This device will act as a master on the SPI bus, deriving SCLK from SMCLK.
-    pub fn as_master_using_smclk(mut self, _smclk: &Smclk, clk_div: u16) -> SpiConfig<USCI, Master> {
+    pub fn to_master_using_smclk(mut self, _smclk: &Smclk, clk_div: u16) -> SpiConfig<USCI, Master> {
         self.ctlw0.ucmst = true;
         self.ctlw0.ucssel = Ucssel::Smclk;
         self.prescaler = clk_div;
         SpiConfig { usci: self.usci, prescaler: self.prescaler, ctlw0: self.ctlw0, _phantom: PhantomData }
     }
     /// This device will act as a master on the SPI bus, deriving SCLK from ACLK.
-    pub fn as_master_using_aclk(mut self, _aclk: &Aclk, clk_div: u16) -> SpiConfig<USCI, Master> {
+    pub fn to_master_using_aclk(mut self, _aclk: &Aclk, clk_div: u16) -> SpiConfig<USCI, Master> {
         self.ctlw0.ucmst = true;
         self.ctlw0.ucssel = Ucssel::Aclk;
         self.prescaler = clk_div;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -299,7 +299,7 @@ impl<USCI: SpiUsci> Spi<USCI> {
     fn recv_byte(&mut self) -> nb::Result<u8, SpiErr> {
         if self.usci.receive_flag() {
             if self.usci.overrun_flag() {
-                Err(nb::Error::Other(SpiErr::OverrunError(self.usci.rxbuf_rd())))
+                Err(nb::Error::Other(SpiErr::Overrun(self.usci.rxbuf_rd())))
             }
             else {
                 Ok(self.usci.rxbuf_rd())
@@ -321,11 +321,9 @@ impl<USCI: SpiUsci> Spi<USCI> {
 
 /// SPI transmit/receive errors
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
 pub enum SpiErr {
     /// Data in the recieve buffer was overwritten before it was read. The contained data is the new contents of the recieve buffer.
-    OverrunError(u8),
-    // In future the framing error bit UCFE may appear here. Right now it's unimplemented.
+    Overrun(u8),
 }
 
 mod ehal1 {
@@ -336,7 +334,7 @@ mod ehal1 {
     impl Error for SpiErr {
         fn kind(&self) -> embedded_hal::spi::ErrorKind {
             match self {
-                SpiErr::OverrunError(_) => embedded_hal::spi::ErrorKind::Overrun,
+                SpiErr::Overrun(_) => embedded_hal::spi::ErrorKind::Overrun,
             }
         }
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -312,8 +312,31 @@ macro_rules! spi_common {
                 Err(WouldBlock)
             }
         }
+
+        /// Get the source of the interrupt currently being serviced.
+        #[inline]
+        pub fn interrupt_source(&mut self) -> SpiVector {
+            match self.usci.iv_rd() {
+                0 => SpiVector::None,
+                2 => SpiVector::RxBufferFull,
+                4 => SpiVector::TxBufferEmpty, 
+                _ => unsafe { core::hint::unreachable_unchecked() }, 
+            }
+        }
     };
 }
+
+/// Possible sources for an eUSCI SPI interrupt
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SpiVector {
+    /// No interrupt is currently being serviced.
+    None = 0,
+    /// The interrupt was caused by the Rx buffer being full.
+    RxBufferFull = 2,
+    /// The interrupt was caused by the Tx buffer being empty.
+    TxBufferEmpty = 4,
+}
+
 /// Represents a group of pins configured for SPI communication
 pub struct Spi<USCI: SpiUsci>{usci: USCI}
 


### PR DESCRIPTION
This PR adds support for SPI slave functionality, alongside a handful of small changes like the addition of an interrupt source method for checking the IV register, a fix for incorrect flushing behaviour, etc. (these are all documented as small atomic commits with descriptions), alongside some new examples.
SPI configuration was modified to allow for configuration into master or slave modes, alongside a shared or exclusive bus. Multi-master SPI was originally supposed to be a part of this, but errata USCI50 make it very error-prone to use and will need a dedicated implementation/workaround.

The CI will fail because of #28 but I've successfully replicated the tests on my machine with a pinned compiler version.