### PR TITLE
Only write to PxOUT during GPIO configuration if necessary

### DIFF
--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -10,6 +10,8 @@ use msp430fr2x5x_hal::{
 };
 use panic_msp430 as _;
 
+// The LED on P1.0 should flash rapidly
+
 #[entry]
 fn main() -> ! {
     let periph = msp430fr2355::Peripherals::take().unwrap();

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+#![feature(asm_experimental_arch)]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    gpio::Batch, pmm::Pmm
+};
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+    
+    // DON'T pause the watchdog
+    //let _wdt = Wdt::constrain(periph.WDT_A);
+    let pmm = Pmm::new(periph.PMM);
+
+    let mut red_led = Batch::new(periph.P1).split(&pmm).pin0.to_output();
+    
+    red_led.toggle().ok();
+
+    // The watchdog will reset program execution after a few ms
+    loop {}
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}


### PR DESCRIPTION
While working on a low power mode implementation for the HAL I found a small bug:
Despite `PxOUT` [maintaining it's value through some reset events](https://dev.ti.com/tirex/explore/node?devices=MSP430FR2355&devtools=MSP430FR2355&node=A__AGp3c1pjwbIUerJVtIxXqg__msp430ware__IOGqZri__LATEST) (namely PUCs - e.g. watchdog timeouts), it was previously impossible to initialise a GPIO pin through the HAL whilst retaining this previous value. This is because `Batch::split()` indiscriminately writes to `PxOUT` (but this is only necessary if the pin is configured as an input with a pull resistor enabled). The previous behaviour is listed below:

- If `Input<Pullup>` set `PxOUT`
- If `Input<Pulldown>` clear `PxOUT`
- If `Input<Floating>` don't care, clear `PxOUT`
- If `Output` clear `PxOUT` (bug!)

The `Input<Floating>` and `Output` modes don't require a write to `PxOUT` to correctly configure the pin, but they get the default value (0) written regardless.

Instead of directly writing to `PxOUT`, we can use a `set_bits()` followed by a `clear_bits()` to allow for setting, clearing, or leaving the value unchanged. The new behaviour is as below:

- If `Input<Pullup>` set `PxOUT`
- If `Input<Pulldown>` clear `PxOUT`
- If `Input<Floating>` don't care (don't change)
- If `Output` don't change

A simple watchdog reset example is enough to demonstrate the problem (and the fix), so I included one of those.

(The CI is still broken because of #28, but it looks like we finally have some movement from the compiler team on that front, so it should hopefully be fixed soon)