### PR TITLE
Add I2C slave, multi-master, master-slave roles + interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Additions
 - Add support for low power modes
 - Add SPI slave support. This includes modifying SPI configuration flow and `SpiErr`.
+- Add support for I2C multi-master, slave, and master-slave roles.
 - Add support for Smart Analog Combo and Enhanced Comparator modules (MSP430FR23xx only)
 - Add support for reading from / writing to backup memory and information memory
 - Add support for hardware CRC module
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Gate embedded-hal 0.2.7 implementations behind `embedded-hal-02` feature.
 - Expose functionality from the traits dropped between eh-0.2.7 and eh-1.0 (ADC, timers, RTC, watchdog, etc.) as methods on structs instead.
 - The SPI struct has been renamed from `SpiBus` to `Spi` to avoid naming conflicts with the new embedded-hal 1.0 trait `SpiBus`.
-- Ensure crate builds successfully back to `nightly-2022-03-01`.
+- Ensure crate builds successfully back to `nightly-2023-09-01`.
 - Replace public references to `void::Void` with `core::convert::Infallible`.
 
 ### Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ panic-never = "0.1.0"
 msp430-rt = "0.4.1"
 critical-section = "1.0.0"
 msp430 = { version = "0.4.0", features = ["critical-section-single-core"] }
+msp430-atomic = "0.1.5"
 
 [profile.release]
 lto = "fat"

--- a/examples/i2c_multiple_masters.rs
+++ b/examples/i2c_multiple_masters.rs
@@ -1,0 +1,139 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+
+// Demonstrates a blocking multi-master implementation, and a blocking and interrupt-based master-slave.
+// The master sends a byte to the master-slave, then switches to read mode. The master-slave echoes the sent value back to the master.
+// The master-slave then probes the bus looking for a device with address 0x09.
+
+// eUSCI B1 is configured as a master-slave. eUSCI B0 is configured as a master.
+// Connect:
+// P1.2 <--> P4.6
+// P1.3 <--> P4.7
+
+// We use UnsafeCell here over RefCell to minimise binary size. Binary size suffers when panics are possible, as they pull in lots of
+// strings and formatting. Debug builds from old compiler versions suffer in particular.
+use core::cell::UnsafeCell;
+
+use critical_section::Mutex;
+use embedded_hal::{delay::DelayNs, digital::OutputPin, i2c::I2c};
+use msp430::interrupt::enable as enable_interrupts;
+use msp430_rt::entry;
+use msp430fr2355::{interrupt, E_USCI_B1};
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv}, fram::Fram, gpio::Batch, 
+    i2c::{GlitchFilter, I2cConfig, I2cInterruptBits, I2cMasterSlave, I2cVector}, pmm::Pmm, watchdog::Wdt
+};
+use panic_msp430 as _;
+
+static I2C_MULTI_MASTER: Mutex<UnsafeCell<Option< I2cMasterSlave<E_USCI_B1> >>> = Mutex::new(UnsafeCell::new(None));
+// Sets the LED on P1.0 if communication is successful, sets the LED on P6.6 if there is no device with address 0x09 on the bus.
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.FRCTL);
+    let _wdt = Wdt::constrain(periph.WDT_A);
+
+    let pmm = Pmm::new(periph.PMM);
+    let p1 = Batch::new(periph.P1).split(&pmm);
+    let mut red_led = p1.pin0.to_output();
+    let mut green_led = Batch::new(periph.P6).split(&pmm).pin6.to_output();
+    let p4 = Batch::new(periph.P4).split(&pmm);
+    let ms_scl = p4.pin7.pullup().to_alternate1(); // You may need stronger external pullup resistors
+    let ms_sda = p4.pin6.pullup().to_alternate1();
+
+    let m_scl = p1.pin3.to_alternate1();
+    let m_sda = p1.pin2.to_alternate1();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.CS)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    // Configure an I2C device as both master and slave. The device will automatically failover from master to slave when addressed.
+    // Attempting any master actions will fail until the slave event has been handled.
+    const MASTER_SLAVE_ADDR: u8 = 26;
+    let mut i2c_master_slave = I2cConfig::new(periph.E_USCI_B1, GlitchFilter::Max50ns)
+        .as_master_slave(MASTER_SLAVE_ADDR)
+        .use_smclk(&smclk, 80) // 8MHz / 80 = 100kHz
+        .configure(ms_scl, ms_sda);
+
+    // Make another I2C device to test the master-slave. Since there are now two masters present
+    // on the bus this has to be a multi-master, rather than a single-master.
+    let mut i2c_master = I2cConfig::new(periph.E_USCI_B0, GlitchFilter::Max50ns)
+        .as_multi_master()
+        .use_smclk(&smclk, 80) // 8MHz / 80 = 100kHz
+        .configure(m_scl, m_sda);
+
+    critical_section::with(|cs| {
+        i2c_master_slave.set_interrupts(I2cInterruptBits::StartReceived);
+        unsafe { *I2C_MULTI_MASTER.borrow(cs).get() = Some(i2c_master_slave) }
+    });
+    unsafe { enable_interrupts() };
+
+    loop {
+        // The master sends a byte then receives a byte from the master-slave.
+        // The master-slave echoes the master's byte back.
+        let mut echo_rx = [0; 1];
+        const ECHO_TX: [u8; 1] = [128; 1];
+
+        // Start a transaction using the master. This will force the master-slave into slave mode.
+        // We don't care about errors for this example, but should be handled in a real implementation.
+        let _ = i2c_master.write_read(MASTER_SLAVE_ADDR, &ECHO_TX, &mut echo_rx);
+
+        // The master-slave is set back into master mode in the StopReceived interrupt, so now we can just use it like a master.
+        // Here we check if a device with address 0x9 is on the bus (aka a zero-byte write)
+        critical_section::with(|cs| {
+            let Some(i2c_master_slave) = unsafe { &mut *I2C_MULTI_MASTER.borrow(cs).get() }.as_mut() else { return; };
+            if let Ok(false) = i2c_master_slave.is_slave_present(9u8) {
+                green_led.set_high().ok(); // Turn on the green LED if address 0x9 is not on bus
+            }
+        });
+
+        // If the I2C devices echoed correctly set the red LED
+        red_led.set_state((echo_rx == ECHO_TX).into()).ok();
+        delay.delay_ms(100);
+    }
+}
+
+// Static mut variables defined inside an interrupt handler are safe. See: https://docs.rust-embedded.org/book/start/interrupts.html
+#[allow(static_mut_refs)]
+#[interrupt]
+fn EUSCI_B1() {
+    static mut TEMP_VAR: u8 = 0;
+    critical_section::with(|cs| {
+        let Some(i2c_master_slave) = unsafe { &mut *I2C_MULTI_MASTER.borrow(cs).get() }.as_mut() else { return; };
+        match i2c_master_slave.interrupt_source() {
+            I2cVector::StartReceived => {
+                // We have been addressed as a slave. Enable Rx, Tx and Stop interrupts.
+                use I2cInterruptBits::*;
+                i2c_master_slave.set_interrupts(TxBufEmpty | RxBufFull | StopReceived);
+            }
+            I2cVector::RxBufFull => {
+                // Store the received value so we can echo it back later when the master switches to read mode
+                *TEMP_VAR = unsafe { i2c_master_slave.read_rx_buf_as_slave_unchecked() };
+            }
+            I2cVector::TxBufEmpty => {
+                // Echo back the stored value
+                unsafe { i2c_master_slave.write_tx_buf_as_slave_unchecked(*TEMP_VAR) };
+            }
+            I2cVector::StopReceived => {
+                // Slave addressing concluded. Disable Rx, Tx, and Stop interrupts. We don't want these to trigger when acting as a master.
+                use I2cInterruptBits::*;
+                i2c_master_slave.clear_interrupts(TxBufEmpty | RxBufFull | StopReceived);
+                i2c_master_slave.return_to_master();
+            }
+            _ => (), // unreachable
+        }
+    })
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/examples/i2c_nb.rs
+++ b/examples/i2c_nb.rs
@@ -1,0 +1,106 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+
+// Demonstrates a non-blocking master implementation, and a polling-based slave.
+// The master sends a byte to the slave, then switches to read mode. The slave receives the value and echoes it back to the master.
+
+// The non-blocking master interface is lower-level than the blocking version (the embedded-hal `I2c` trait)
+// and requires more careful usage.
+
+// eUSCI B1 is configured as the slave. eUSCI B0 is configured as the master.
+// Connect:
+// P1.2 <--> P4.6
+// P1.3 <--> P4.7
+
+use embedded_hal::{digital::{OutputPin, StatefulOutputPin}, delay::DelayNs};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv}, fram::Fram, gpio::Batch, 
+    i2c::{GlitchFilter, I2cConfig, I2cEvent, TransmissionMode}, pmm::Pmm, watchdog::Wdt
+};
+use panic_msp430 as _;
+
+// Blink the red LED on P1.0 every time an I2C transaction occurs. Green LED on P6.6 is on if Tx/Rx echo is successful.
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.FRCTL);
+    let _wdt = Wdt::constrain(periph.WDT_A);
+
+    let pmm = Pmm::new(periph.PMM);
+    let p1 = Batch::new(periph.P1).split(&pmm);
+    let mut red_led = p1.pin0.to_output();
+    let mut green_led = Batch::new(periph.P6).split(&pmm).pin6.to_output();
+    let p4 = Batch::new(periph.P4).split(&pmm);
+    let sl_scl = p4.pin7.to_alternate1();
+    let sl_sda = p4.pin6.to_alternate1();
+
+    let m_scl = p1.pin3.pullup().to_alternate1(); // You may need stronger external pullup resistors
+    let m_sda = p1.pin2.pullup().to_alternate1();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.CS)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let mut i2c_master = I2cConfig::new(periph.E_USCI_B0, GlitchFilter::Max50ns)
+        .as_single_master()
+        .use_smclk(&smclk, 80) // 8MHz / 80 = 100kHz
+        .configure(m_scl, m_sda);
+
+    const SLAVE_ADDR: u8 = 0x1A;
+    let mut i2c_slave = I2cConfig::new(periph.E_USCI_B1, GlitchFilter::Max50ns)
+        .as_slave(SLAVE_ADDR)
+        .configure(sl_scl, sl_sda);
+
+    loop {
+        // The master sends a byte then receives a byte.
+        // The slave echoes the master's byte back.
+
+        // Master transmit
+        i2c_master.send_start(SLAVE_ADDR, TransmissionMode::Transmit);
+        const ECHO_TX: u8 = 10;
+        let _ = nb::block!(i2c_master.write_tx_buf(ECHO_TX)); // Safe, slave doesn't send NACKs
+
+        // Slave receive
+        loop {
+            if i2c_slave.poll() == Ok(I2cEvent::WriteStart) { break }
+        }
+        let byte = unsafe { i2c_slave.read_rx_buf_unchecked() }; // Safe since `poll` returned a Write event
+
+        // Master swaps mode
+        i2c_master.send_start(SLAVE_ADDR, TransmissionMode::Receive);
+
+        // Slave transmit
+        loop {
+            if i2c_slave.poll() == Ok(I2cEvent::ReadStart) { break }
+        }
+        let _ = nb::block!(i2c_slave.write_tx_buf(byte)); // Safe, infallible
+
+        // Master receive
+        // A stop must be scheduled now (rather than *after* reading the Rx buffer),
+        // as otherwise the bus will start the next byte then stall waiting for more data
+        i2c_master.schedule_stop();
+        let echo_rx = nb::block!(i2c_master.read_rx_buf()).unwrap_or(0); // Safe, slave doesn't send NACKs
+
+        loop {
+            if i2c_slave.poll() == Ok(I2cEvent::Stop) { break }
+        }
+
+        // Enable the LED if the echoed value matches what was sent.
+        green_led.set_state((echo_rx == ECHO_TX).into()).ok();
+        red_led.toggle().ok();
+        delay.delay_ms(100);
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/examples/i2c_slave_interrupt.rs
+++ b/examples/i2c_slave_interrupt.rs
@@ -1,0 +1,152 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+
+// This I2C slave implements reading and writing from a 10-byte array.
+// If a transaction begins with a write, the first byte is treated as the desired array index.
+// A subsequent write provides data to store at the specified index. Additional writes will be stored at the following indices, the index autoincrementing after each.
+// After any number of writes the master may perform a Repeated Start and switch to reading in order to retrieve the value at the specified index.
+// Further reads will read the subsequent indices, autoincrementing.
+// If a transaction does not begin with a write, then the index from the previous transaction is used.
+// If no previous transaction has been performed the index defaults to 0.
+
+// eUSCI B0 is configured as the master, B1 as the slave.
+// Connect:
+// P1.2 <--> P4.6.
+// P1.3 <--> P4.7.
+
+// This example is quite big (particularly debug builds on old compiler versions), so we use a couple of tricks here to shrink binary size:
+// Anything that can panic (like RefCell) will pull in some string formatting, which bloats the binary! Instead use UnsafeCell (carefully).
+// Likewise avoid panics from array bounds checks by using .get_unchecked(), etc.
+
+use core::cell::UnsafeCell;
+
+use critical_section::Mutex;
+use msp430::interrupt::enable as enable_interrupts;
+use embedded_hal::{delay::DelayNs, digital::{OutputPin, StatefulOutputPin}, i2c::I2c};
+use msp430_atomic::AtomicU8;
+use msp430_rt::entry;
+use msp430fr2355::{interrupt, E_USCI_B1};
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    i2c::{GlitchFilter, I2cConfig, I2cInterruptBits, I2cSlave, I2cVector},
+    pmm::Pmm,
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+static I2C_SLAVE: Mutex<UnsafeCell<Option< I2cSlave<E_USCI_B1> >>> = Mutex::new(UnsafeCell::new(None));
+
+// Store the exposed 'registers' as Atomic values, so they can be easily read/written to between the interrupt and main fn
+const ARR_LEN: usize = 8;
+static ARR: [AtomicU8; ARR_LEN] = [const { AtomicU8::new(0) }; ARR_LEN];
+
+// Red LED on P1.0 should blink rapidly. Green LED on pin P6.6 should blink once for every ten red blinks.
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.FRCTL);
+    let _wdt = Wdt::constrain(periph.WDT_A);
+
+    let pmm = Pmm::new(periph.PMM);
+    let p1 = Batch::new(periph.P1).split(&pmm);
+    let mut red_led = p1.pin0.to_output();
+    let mut green_led = Batch::new(periph.P6).split(&pmm).pin6.to_output();
+    let p4 = Batch::new(periph.P4).split(&pmm);
+    let sl_scl = p4.pin7.to_alternate1();
+    let sl_sda = p4.pin6.to_alternate1();
+
+    let scl = p1.pin3.pullup().to_alternate1(); // You may need stronger external pullup resistors
+    let sda = p1.pin2.pullup().to_alternate1();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.CS)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let mut i2c_master = I2cConfig::new(periph.E_USCI_B0, GlitchFilter::Max50ns)
+        .as_single_master()
+        .use_smclk(&smclk, 80) // 8MHz / 80 = 100kHz
+        .configure(scl, sda);
+
+    const SLAVE_ADDR: u8 = 0x1A;
+    let mut i2c_slave = I2cConfig::new(periph.E_USCI_B1, GlitchFilter::Max50ns)
+        .as_slave(SLAVE_ADDR)
+        .configure(sl_scl, sl_sda);
+
+    use I2cInterruptBits::*;
+    i2c_slave.set_interrupts(StopReceived | RxBufFull | TxBufEmpty);
+
+    critical_section::with(|cs| {
+        unsafe { *I2C_SLAVE.borrow(cs).get() = Some(i2c_slave) }
+    });
+
+    unsafe { enable_interrupts(); }
+
+    let index = 0;
+    let mut value = 0;
+    loop {
+        // Write a value between 0 and 9 to index 0.
+        let _ = i2c_master.write(SLAVE_ADDR, &[index, value]);
+        value = (value + 1) % 10;
+
+        // Enable the green LED if the value at index 0 is 0.
+        green_led.set_state((ARR[0].load() == 0).into()).ok();
+
+        // Toggle the red LED after each
+        red_led.toggle().ok();
+        delay.delay_ms(100);
+    }
+}
+
+// Static mut variables defined inside an interrupt handler are safe. See: https://docs.rust-embedded.org/book/start/interrupts.html
+#[allow(static_mut_refs)]
+#[interrupt]
+fn EUSCI_B1() {
+    static mut BYTE_COUNT: u8 = 0; // Bytes since the initial start condition
+    static mut ARR_INDEX: usize = 0;
+
+    critical_section::with(|cs| {
+        let Some(i2c_slave) = unsafe { &mut *I2C_SLAVE.borrow(cs).get() }.as_mut() else { return; };
+        match i2c_slave.interrupt_source() {
+            I2cVector::RxBufFull => {
+                // Safety: Rx interrupt triggered, so Rx buffer is ready.
+                let val = unsafe { i2c_slave.read_rx_buf_unchecked() };
+                // If this is the first byte treat the I2C byte as the array index
+                if *BYTE_COUNT == 0 {
+                    *ARR_INDEX = val as usize % ARR_LEN;
+                } else {
+                    // Otherwise treat the I2C byte as data to be stored
+                    unsafe { ARR.get_unchecked(*ARR_INDEX) }.store(val);
+                    *ARR_INDEX = (*ARR_INDEX + 1) % ARR_LEN; // Autoincrement index
+                }
+            }
+            I2cVector::TxBufEmpty => {
+                // Safety: ARR_INDEX is always less than ARR_LEN.
+                let val = unsafe { ARR.get_unchecked(*ARR_INDEX) }.load();
+                // Safety: Tx interrupt triggered, so Tx buffer is ready.
+                unsafe { i2c_slave.write_tx_buf_unchecked(val) };
+                *ARR_INDEX = (*ARR_INDEX + 1) % ARR_LEN; // Autoincrement index
+            }
+            I2cVector::StopReceived => {
+                *ARR_INDEX = ARR_INDEX.wrapping_sub(1).min(ARR_LEN - 1); // Undo last autoincrement
+                *BYTE_COUNT = 0;
+                return;
+            }
+            _ => (), // unreachable
+        }
+        *BYTE_COUNT += 1;
+    })
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/src/hw_traits/eusci.rs
+++ b/src/hw_traits/eusci.rs
@@ -246,6 +246,8 @@ pub trait EUsciI2C: Steal {
     fn brw_rd(&self) -> u16;
     fn brw_wr(&self, val: u16);
 
+    fn byte_count(&self) -> u8; 
+
     // Modify only when UCSWRST = 1
     fn tbcnt_rd(&self) -> u16;
     fn tbcnt_wr(&self, val: u16);
@@ -768,6 +770,11 @@ macro_rules! eusci_b_impl {
             #[inline(always)]
             fn brw_wr(&self, val: u16) {
                 self.$ucbxbrw().write(|w| unsafe { w.bits(val) });
+            }
+
+            #[inline(always)]
+            fn byte_count(&self) -> u8 {
+                self.$ucbxstatw().read().ucbcnt().bits()
             }
 
             #[inline(always)]

--- a/src/hw_traits/eusci.rs
+++ b/src/hw_traits/eusci.rs
@@ -61,12 +61,17 @@ pub enum Ucmode {
     I2CMode = 3,
 }
 
+/// Configure the automatic glitch filter on the SDA and SCL lines
 #[derive(Copy, Clone, Default)]
 pub enum Ucglit {
+    /// Pulses of maximum 50-ns length are filtered.
     #[default]
     Max50ns = 0,
+    /// Pulses of maximum 25-ns length are filtered.
     Max25ns = 1,
+    /// Pulses of maximum 12.5-ns length are filtered.
     Max12_5ns = 2,
+    /// Pulses of maximum 6.25-ns length are filtered.
     Max6_25ns = 3,
 }
 
@@ -149,54 +154,11 @@ pub struct UcbCtlw1, UcbCtlw1_rd, UcbCtlw1_wr {
 }
 
 // in order to avoid 4 separate structs, I manually implemented the macro for these registers
+#[derive(Debug, Default)]
 pub struct UcbI2coa {
     pub ucgcen: bool,
     pub ucoaen: bool,
     pub i2coa0: u16,
-}
-
-reg_struct! {
-pub struct UcbIe, UcbIe_rd, UcbIe_wr {
-    flags{
-        pub ucbit9ie: bool,
-        pub uctxie3: bool,
-        pub ucrxie3: bool,
-        pub uctxie2: bool,
-        pub ucrxie2: bool,
-        pub uctxie1: bool,
-        pub ucrxie1: bool,
-        pub uccltoie: bool,
-        pub ucbcntie: bool,
-        pub ucnackie: bool,
-        pub ucalie: bool,
-        pub ucstpie: bool,
-        pub ucsttie: bool,
-        pub uctxie0: bool,
-        pub ucrxie0: bool,
-    }
-}
-}
-
-reg_struct! {
-pub struct UcbIFG, UcbIFG_rd, UcbIFG_wr{
-    flags{
-        pub ucbit9ifg: bool,
-        pub uctxifg3: bool,
-        pub ucrxifg3: bool,
-        pub uctxifg2: bool,
-        pub ucrxifg2: bool,
-        pub uctxifg1: bool,
-        pub ucrxifg1: bool,
-        pub uccltoifg: bool,
-        pub ucbcntifg: bool,
-        pub ucnackifg: bool,
-        pub ucalifg: bool,
-        pub ucstpifg: bool,
-        pub ucsttifg: bool,
-        pub uctxifg0: bool,
-        pub ucrxifg0: bool,
-    }
-}
 }
 
 reg_struct! {
@@ -305,10 +267,10 @@ pub trait EUsciI2C: Steal {
     fn i2csa_rd(&self) -> u16;
     fn i2csa_wr(&self, val: u16);
 
-    fn ie_wr(&self, reg: &UcbIe);
+    fn ie_wr(&self, reg: u16);
 
     fn ifg_rd(&self) -> Self::IfgOut;
-    fn ifg_wr(&self, reg: &UcbIFG);
+    fn ifg_wr(&self, reg: u16);
     fn ifg_rst(&self);
 
     fn iv_rd(&self) -> u16;
@@ -917,8 +879,8 @@ macro_rules! eusci_b_impl {
             }
 
             #[inline(always)]
-            fn ie_wr(&self, reg: &UcbIe) {
-                self.$ucbxie().write(UcbIe_wr! {reg});
+            fn ie_wr(&self, reg: u16) {
+                self.$ucbxie().write(|w| unsafe { w.bits(reg) });
             }
 
             #[inline(always)]
@@ -927,8 +889,8 @@ macro_rules! eusci_b_impl {
             }
 
             #[inline(always)]
-            fn ifg_wr(&self, reg: &UcbIFG) {
-                self.$ucbxifg().write(UcbIFG_wr! {reg});
+            fn ifg_wr(&self, reg: u16) {
+                self.$ucbxifg().write(|w| unsafe { w.bits(reg) });
             }
 
             #[inline(always)]

--- a/src/hw_traits/eusci.rs
+++ b/src/hw_traits/eusci.rs
@@ -270,6 +270,8 @@ pub trait EUsciI2C: Steal {
     fn i2csa_wr(&self, val: u16);
 
     fn ie_wr(&self, reg: u16);
+    fn ie_set(&self, mask: u16);
+    fn ie_clr(&self, mask: u16);
 
     fn ifg_rd(&self) -> Self::IfgOut;
     fn ifg_wr(&self, reg: u16);
@@ -888,6 +890,15 @@ macro_rules! eusci_b_impl {
             #[inline(always)]
             fn ie_wr(&self, reg: u16) {
                 self.$ucbxie().write(|w| unsafe { w.bits(reg) });
+            }
+
+            #[inline(always)]
+            fn ie_set(&self, mask: u16) {
+                unsafe{ self.$ucbxie().set_bits(|w| w.bits(mask)) };
+            }
+            #[inline(always)]
+            fn ie_clr(&self, mask: u16) {
+                unsafe{ self.$ucbxie().clear_bits(|w| w.bits(mask)) };
             }
 
             #[inline(always)]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -303,6 +303,47 @@ macro_rules! i2c_common {
         pub fn byte_count(&mut self) -> u8 {
             self.usci.byte_count()
         }
+
+        /// Get the event that triggered the current interrupt. Used as part of the interrupt-based interface.
+        pub fn interrupt_source(&mut self) -> I2cVector {
+            use I2cVector::*;
+            match self.usci.iv_rd() {
+                0x00 => None,
+                0x02 => ArbitrationLost,
+                0x04 => NackReceived,
+                0x06 => StartReceived,
+                0x08 => StopReceived,
+                0x0A => Slave3RxBufFull,
+                0x0C => Slave3TxBufEmpty,
+                0x0E => Slave2RxBufFull,
+                0x10 => Slave2TxBufEmpty,
+                0x12 => Slave1RxBufFull,
+                0x14 => Slave1TxBufEmpty,
+                0x16 => RxBufFull,
+                0x18 => TxBufEmpty,
+                0x1A => ByteCounterZero,
+                0x1C => ClockLowTimeout,
+                0x1E => NinthBitReceived,
+                _ => unsafe { core::hint::unreachable_unchecked() },
+            }
+        }
+
+        /// Set the bits in the interrupt enable register that correspond to the bits set in `intrs`.
+        ///
+        /// This bitmask can be generated using [`I2cInterruptBits`].
+        #[inline(always)]
+        pub fn set_interrupts<I2cInterruptBits>(&mut self, intrs: I2cInterruptBits)
+        where I2cInterruptBits: Into<u16> {
+            self.usci.ie_set(intrs.into())
+        }
+        /// Clear the bits in the interrupt enable register that correspond to the bits *set* in `intrs`.
+        ///
+        /// This bitmask can be generated using [`I2cInterruptBits`].
+        #[inline(always)]
+        pub fn clear_interrupts<I2cInterruptBits>(&mut self, intrs: I2cInterruptBits)
+        where I2cInterruptBits: Into<u16> {
+            self.usci.ie_clr(!(intrs.into()))
+        }
     };
 }
 
@@ -566,6 +607,118 @@ pub enum I2cSingleMasterErr {
     /// methods this value counts up from the most recent Start or Repeated Start condition.
     GotNACK(usize),
     // Other errors like the 'clock low timeout' UCCLTOIFG may appear here in future.
+}
+
+/// List of possible I2C interrupt sources. 
+/// 
+/// Used when reading from the I2C interrupt vector register via [`interrupt_source()`](I2cSingleMaster::interrupt_source())
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum I2cVector {
+    /// No interrupt.
+    None                = 0x00,
+    /// Arbitration was lost during an attempted transmission.
+    ArbitrationLost     = 0x02,
+    /// Received a NACK.
+    NackReceived        = 0x04,
+    /// Received a Start condition on the I2C bus along with one of our own addresses.
+    StartReceived       = 0x06,
+    /// Received a Stop condition on the I2C bus.
+    /// This is usually set when acting as an I2C slave, but that this can occur as an I2C master during a zero byte write.
+    StopReceived        = 0x08,
+    /// Slave address 3 received a data byte.
+    Slave3RxBufFull     = 0x0A,
+    /// The Tx buffer is empty and slave address 3 was on the I2C bus when this occurred.
+    Slave3TxBufEmpty    = 0x0C,
+    /// Slave address 2 received a data byte.
+    Slave2RxBufFull     = 0x0E,
+    /// The Tx buffer is empty and slave address 2 was on the I2C bus when this occurred.
+    Slave2TxBufEmpty    = 0x10,
+    /// Slave address 1 received a data byte.
+    Slave1RxBufFull     = 0x12,
+    /// The Tx buffer is empty and slave address 1 was on the I2C bus when this occurred.
+    Slave1TxBufEmpty    = 0x14,
+    /// Data is waiting in the Rx buffer. In slave mode slave address 0 was on the I2C bus when this occurred.
+    RxBufFull           = 0x16,
+    /// The Tx buffer is empty. In slave mode slave address 0 was on the I2C bus when this occurred.
+    TxBufEmpty          = 0x18,
+    /// The target byte count has been reached.
+    ByteCounterZero     = 0x1A,
+    /// The SCL line has been held low longer than the Clock Low Timeout value.
+    ClockLowTimeout     = 0x1C,
+    /// The 9th bit of an I2C data packet has been completed.
+    NinthBitReceived    = 0x1E,
+}
+
+/// Human-friendly list of possible I2C interrupt source flags.
+/// 
+/// Used for writing to the I2C interrupt enable register e.g. via the [`set_interrupts()`](I2cSingleMaster::set_interrupts()) method.
+/// 
+/// Example usage:
+/// ```ignore
+/// use I2cInterruptBits::*;
+/// i2c_device.set_interrupts(RxBufFull | TxBufEmpty | StopReceived);
+/// ```
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u16)]
+pub enum I2cInterruptBits {
+    /// UCRXIE0. Trigger an interrupt when data is waiting in the Rx buffer. In slave mode slave address 0 must be on the I2C bus when this occurred.
+    RxBufFull           = 1 << 0,
+    /// UCTXIE0. Trigger an interrupt when the Tx buffer is empty. In slave mode slave address 0 must be on the I2C bus when this occurred.
+    TxBufEmpty          = 1 << 1,
+    /// UCSTTIE. Trigger an interrupt when a Start condition is received on the I2C bus along with one of our own addresses.
+    StartReceived       = 1 << 2,
+    /// UCSTPIE. Trigger an interrupt when a Stop condition is received on the I2C bus in a transaction we are a part of.
+    /// Typically this triggers when acting as an I2C slave, but this also triggers as an I2C master during a zero byte write.
+    StopReceived        = 1 << 3,
+    /// UCALIE. Trigger an interrupt when arbitration was lost during an attempted transmission.
+    ArbitrationLost     = 1 << 4,
+    /// UCNACKIE. Trigger an interrupt a NACK is received.
+    NackReceived        = 1 << 5,
+    /// UCBCNTIE. Trigger an interrupt when the target byte count has been reached.
+    ByteCounterZero     = 1 << 6,
+    /// UCCLTOIE. Trigger an interrupt when the SCL line has been held low longer than the Clock Low Timeout value.
+    ClockLowTimeout     = 1 << 7,
+    /// UCRXIE1. Trigger an interrupt when slave address 1 receives a data byte.
+    Slave1RxBufFull     = 1 << 8,
+    /// UCTXIE1. Trigger an interrupt when the Tx buffer is empty and slave address 1 was on the I2C bus when this occurred.
+    Slave1TxBufEmpty    = 1 << 9,
+    /// UCRXIE2. Trigger an interrupt when slave address 2 receives a data byte.
+    Slave2RxBufFull     = 1 << 10,
+    /// UCTXIE2. Trigger an interrupt when the Tx buffer is empty and slave address 2 was on the I2C bus when this occurred.
+    Slave2TxBufEmpty    = 1 << 11,
+    /// UCRXIE3. Trigger an interrupt when slave address 3 receives a data byte.
+    Slave3RxBufFull     = 1 << 12,
+    /// UCTXIE3. Trigger an interrupt when the Tx buffer is empty and slave address 3 was on the I2C bus when this occurred.
+    Slave3TxBufEmpty    = 1 << 13,
+    /// UCBIT9IE. Trigger an interrupt when the 9th bit of an I2C data packet we are involved in has been completed.
+    NinthBitReceived    = 1 << 14,
+}
+impl From<I2cInterruptBits> for u16 {
+    #[inline(always)]
+    fn from(value: I2cInterruptBits) -> Self {
+        value as u16
+    }
+}
+impl core::ops::BitOr for I2cInterruptBits {
+    type Output = u16;
+    #[inline(always)]
+    fn bitor(self, rhs: Self) -> Self::Output {
+        (self as u16) | (rhs as u16)
+    }
+}
+impl core::ops::BitOr<u16> for I2cInterruptBits {
+    type Output = u16;
+    #[inline(always)]
+    fn bitor(self, rhs: u16) -> Self::Output {
+        (self as u16) | rhs
+    }
+}
+impl core::ops::BitOr<I2cInterruptBits> for u16 {
+    type Output = u16;
+    #[inline(always)]
+    fn bitor(self, rhs: I2cInterruptBits) -> Self::Output {
+        self | (rhs as u16)
+    }
 }
 
 // Trait to link embedded-hal types to our addressing mode enum.

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -9,7 +9,7 @@
 //!
 //! # [`Spi`]
 //! The SPI peripheral can be configured as a master device by calling one of the
-//! [`as_master()`](SpiConfig::as_master_using_smclk) methods during configuration.
+//! [`to_master()`](SpiConfig::to_master_using_smclk) methods during configuration.
 //!
 //! [`Spi`] implements the embedded-hal [`SpiBus`](embedded_hal::spi::SpiBus) trait, which provides a simple blocking interface.
 //! A non-blocking implementation is also available through [`embedded-hal-nb`](embedded_hal_nb)'s
@@ -17,7 +17,7 @@
 //! Standalone methods are also provided for directly writing to the Tx and Rx buffers for interrupt-based implementations.
 //!
 //! # [`SpiSlave`]
-//! The SPI peripheral can be configured as a slave device by calling [`as_slave()`](SpiConfig::as_slave) during configuration.
+//! The SPI peripheral can be configured as a slave device by calling [`to_slave()`](SpiConfig::to_slave) during configuration.
 //!
 //! [`SpiSlave`] supports sharing the bus with other slave devices by calling the [`shared_bus()`](SpiConfig::shared_bus) method
 //! during configuration. In this mode the STE pin controls whether the MISO pin is an output or a high-impedance pin, allowing


### PR DESCRIPTION
Last addition I have planned for the moment - I2C has been expanded to allow for the MSP to act as a slave, multi-master, or master-slave. Non-blocking / interrupt-based implementations were added too. 

Since a lot of the implementation details are identical between the different roles (e.g. all the master variants have access to general master methods like starting a transaction) and the only difference is generally the amount and type of error handling, the base implementation have been moved into macros like `i2c_masters!()` that implement the core logic for roles of the corresponding type.

I discovered a couple small bugs during the refactoring process so there are a couple minor modifications to the underlying blocking write function.

I've added examples for the various roles (including master + slave interactions between two eUSCI peripherals) and additionally confirmed everything looks correct on an oscilloscope. I've also verified that the previous master implementation still works against external I2C devices, though I haven't been able to test an arbitration loss scenario or the MSP being addressed as a slave by an external device.

This required moving a lot of code around, so I'd suggest going through the commits individually. Most commits are straightfoward, but the actual refactor commit (b31ea06bdd507bb7fa34eaab37dc7d9759ca01d2) is messy and the github diff can't make much sense of it. My git client (and vscode) provided much more useful diffs than github, so if you want to validate that one you may want to view the diff externally. Here's an example of the not terrifly useful github diff: 
<img width="1930" height="853" alt="image" src="https://github.com/user-attachments/assets/d63bd7d6-9edd-452a-9fd8-29f0ae86aa78" />
and what it should look like instead:
<img width="1675" height="422" alt="image" src="https://github.com/user-attachments/assets/6f107012-c197-4cf5-9c51-a1adad98e21b" />