### PR TITLE
Add defmt support and small fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         rust_toolchain: [nightly, nightly-2024-09-01]
-        device: [msp430fr2355, msp430fr2476]
+        device: [msp430fr2355, msp430fr2476, msp430fr2433]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,17 +52,4 @@ jobs:
       - name: Build MSRV examples
         if: matrix.rust_toolchain != 'nightly'
         working-directory: device-examples/${{matrix.device}}
-        shell: bash
-        run: |
-          for ex in examples/*.rs; do
-            # Skip examples that rely on non-MSRV features 
-            case "$(basename $ex)" in
-              lpm0.rs)
-                echo "Skipping $ex"
-                ;;
-              *)
-                echo "Building $ex"
-                cargo +${{matrix.rust_toolchain}} build --example "$(basename $ex .rs)"
-                ;;
-            esac
-          done
+        run: cargo build --examples --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Add support for the MSP430FR247x subfamily.
 - Add support for pin remapping on certain peripherals on certain devices (like the FR247x subfamily). For devices that don't support pin remapping this should be invisible for the most part.
+- Add defmt support through `defmt` feature flag.
 
 ## [v0.6.1] - 2026-03-11
 - Fix missing readme on crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Add support for the MSP430FR247x subfamily.
+- Add support for pin remapping on certain peripherals on certain devices (like the FR247x subfamily). For devices that don't support pin remapping this should be invisible for the most part.
+
 ## [v0.6.1] - 2026-03-11
 - Fix missing readme on crates.io
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for the MSP430FR247x subfamily.
 - Add support for pin remapping on certain peripherals on certain devices (like the FR247x subfamily). For devices that don't support pin remapping this should be invisible for the most part.
 - Add defmt support through `defmt` feature flag.
+- Optimised GPIO toggling implementation
 
 ## [v0.6.1] - 2026-03-11
 - Fix missing readme on crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for pin remapping on certain peripherals on certain devices (like the FR247x subfamily). For devices that don't support pin remapping this should be invisible for the most part.
 - Add defmt support through `defmt` feature flag.
 - Optimised GPIO toggling implementation
+- Fixed a bug around enabling/disabling the PWM on the FR2433 Timer1 peripheral.
 
 ## [v0.6.1] - 2026-03-11
 - Fix missing readme on crates.io

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ PRs with implementations for these peripherals are welcome.
 
 In addition to the device feature flags mentioned above, this crate provides an implementation of the legacy 0.2.7 version of embedded-hal behind the `embedded-hal-02` feature. Support for embedded-hal 1.0 is available by default.
 
+Support for `defmt` is available through the `defmt` feature. See `device_examples/msp430fr2355/defmt.rs` for a defmt implementation on the MSP430.
+
 # Minimum Supported Rust Version (MSRV)
 
 This crate requires the `nightly` toolchain to compile, currently targetting `nightly-2024-09-01` 

--- a/device-examples/msp430fr2355/.cargo/config.toml
+++ b/device-examples/msp430fr2355/.cargo/config.toml
@@ -6,6 +6,7 @@ runner = "./run.sh"
 
 rustflags = [
     "-C", "link-arg=-nostartfiles",
+    "-C", "link-arg=-Tdefmt.x", # required for defmt. Must appear before `Tlink.x`
     "-C", "link-arg=-Tlink.x",
     "-C", "link-arg=-mcpu=msp430",
 

--- a/device-examples/msp430fr2355/Cargo.toml
+++ b/device-examples/msp430fr2355/Cargo.toml
@@ -8,18 +8,22 @@ publish = false
 keywords = ["no-std", "msp430", "ti", "launchpad", "embedded-hal"]
 
 [dependencies]
+defmt = "1.0"
+defmt-serial = "0.12"
 panic-msp430 = "0.4.0"
 panic-never = "0.1.0"
 msp430 = {version = "0.4.1", features = ["critical-section-single-core"]}
 msp430-rt = "0.4.0"
 msp430fr2355 = {version = "0.6", features = ["rt", "critical-section"]}
-msp430fr2x5x-hal = {path = "../../hal", features = ["msp430fr2355"]}
+msp430fr2x5x-hal = {path = "../../hal", features = ["msp430fr2355", "defmt"]}
 critical-section = "1.2.0"
 msp430-atomic = "0.1.5"
 embedded-hal = "1.0"
 embedded-hal-nb = "*"
-embedded-io = "0.6"
+embedded-io = "0.7"
 nb = "1.1.0"
+portable-atomic = { version = "1.13", default-features = false }
+static_cell = "2.1"
 
 [profile.release]
 lto = "fat"

--- a/device-examples/msp430fr2355/Cargo.toml
+++ b/device-examples/msp430fr2355/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no-std", "msp430", "ti", "launchpad", "embedded-hal"]
 
 [dependencies]
 defmt = "1.0"
-defmt-serial = "0.12"
+defmt-serial = {version = "0.12", optional=true}
 panic-msp430 = "0.4.0"
 panic-never = "0.1.0"
 msp430 = {version = "0.4.1", features = ["critical-section-single-core"]}
@@ -37,3 +37,18 @@ debug = true
 
 [profile.dev.package."*"]
 opt-level = "z"
+
+
+# Mark which examples don't work on the MSRV compiler, so CI doesn't build them when using the MSRV.
+# By default all examples are enabled, building with MSRV requires passing `--no-default-features`.
+[features]
+default = ["non_msrv"]
+non_msrv = ["dep:defmt-serial"]
+
+# Examples that don't work on the MSRV compiler
+[[example]]
+name = "defmt"
+required-features = ["non_msrv"]
+[[example]]
+name = "lpm0"
+required-features = ["non_msrv"]

--- a/device-examples/msp430fr2355/examples/defmt.rs
+++ b/device-examples/msp430fr2355/examples/defmt.rs
@@ -1,0 +1,74 @@
+#![no_main]
+#![no_std]
+
+use defmt_serial::defmt_serial;
+use embedded_hal::{delay::DelayNs, digital::OutputPin};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram, 
+    gpio::*, 
+    pmm::Pmm, 
+    serial::*, 
+    watchdog::Wdt
+};
+use msp430fr2355::EUsciA0;
+use panic_msp430 as _;
+use static_cell::StaticCell;
+
+// Configure UART, then print "Hello!" over eUSCI_A0 using defmt once per second.
+
+// Messages can be received using (a serial to USB adapter and) `defmt-print`, e.g.:
+// stty -F /dev/ttyUSB0 9600 raw; cat /dev/ttyUSB0 | defmt-print -w -e ./target/msp430-none-elf/debug/examples/defmt
+// Note: Using defmt also requires adding the defmt linker script to .cargo/config.toml
+
+// Once configured, our UART peripheral will live here.
+// This allows for printing from anywhere, including interrupts and panics.
+static SERIAL: StaticCell<Tx<EUsciA0>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr2355::Peripherals::take().unwrap();
+    let mut fram = Fram::new(periph.frctl);
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+    let mut led = p1.pin0.to_output();
+    led.set_low().ok();
+
+    let (_smclk, aclk, mut delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_2)
+        .aclk_refoclk()
+        .freeze(&mut fram);
+
+    let tx = SerialConfig::new(
+        periph.e_usci_a0,
+        BitOrder::LsbFirst,
+        BitCount::EightBits,
+        StopBits::OneStopBit,
+        Parity::NoParity,
+        Loopback::NoLoop,
+        9600,
+    )
+    .use_aclk(&aclk)
+    .tx_only(p1.pin7.to_alternate1());
+
+    // Tell defmt to use our serial peripheral
+    defmt_serial(SERIAL.init(tx));
+
+    led.set_high();
+    loop {
+        delay.delay_ms(1000);
+        defmt::println!("Hello!");
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2433/Cargo.toml
+++ b/device-examples/msp430fr2433/Cargo.toml
@@ -18,7 +18,7 @@ critical-section = "1.2.0"
 msp430-atomic = "0.1.5"
 embedded-hal = "1.0"
 embedded-hal-nb = "*"
-embedded-io = "0.6"
+embedded-io = "0.7"
 nb = "1.1.0"
 
 [profile.release]

--- a/device-examples/msp430fr2476/Cargo.toml
+++ b/device-examples/msp430fr2476/Cargo.toml
@@ -18,7 +18,7 @@ critical-section = "1.2.0"
 msp430-atomic = "0.1.5"
 embedded-hal = "1.0"
 embedded-hal-nb = "*"
-embedded-io = "0.6"
+embedded-io = "0.7"
 nb = "1.1.0"
 
 [profile.release]

--- a/device-examples/msp430fr2476/Cargo.toml
+++ b/device-examples/msp430fr2476/Cargo.toml
@@ -33,3 +33,14 @@ debug = true
 
 [profile.dev.package."*"]
 opt-level = "z"
+
+# Mark which examples don't work on the MSRV compiler, so CI doesn't build them when using the MSRV.
+# By default all examples are enabled, building with MSRV requires passing `--no-default-features`.
+[features]
+default = ["non_msrv"]
+non_msrv = []
+
+# Examples that don't work on the MSRV compiler
+[[example]]
+name = "lpm0"
+required-features = ["non_msrv"]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 [features]
 default = []
 embedded-hal-02 = ["dep:embedded-hal-02", "dep:void"]
+defmt = ["dep:defmt"]
 
 # Device features. Provide exactly one of these.
 msp430fr2355 = ["2x5x", "sac_l3"] # 32kB FRAM + SAC unit
@@ -42,6 +43,7 @@ info_mem = []
 vloclk_source = []
 
 [dependencies]
+defmt = {version = "1.0", optional = true }
 msp430 = "0.4.0"
 msp430fr2355 = { version = "0.6", features = ["rt", "critical-section"], optional = true }
 msp430fr2433 = { version = "0.2", features = ["rt", "critical-section"], optional = true }
@@ -51,7 +53,7 @@ void = { version = "1.0.2", default-features = false, optional = true }
 embedded-hal-02 = { package = 'embedded-hal', version = "0.2.7", features = ["unproven"], optional = true }
 embedded-hal = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
-embedded-io = "0.6"
+embedded-io = "0.7"
 bitflags = "2.9"
 
 [dev-dependencies]

--- a/hal/src/capture.rs
+++ b/hal/src/capture.rs
@@ -424,6 +424,7 @@ impl<T: CapCmp<C>, C> Capture<T, C> {
 }
 
 /// Error returned when the previous capture was overwritten before being read
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OverCapture(pub u16);
 
 /// Capture TBIV interrupt vector

--- a/hal/src/device_specific/fr2433.rs
+++ b/hal/src/device_specific/fr2433.rs
@@ -181,11 +181,11 @@ mod pwm {
     // TA1
     impl PwmPeriph<CCR1> for Timer1A3 {
         type Gpio = Pin<P1, Pin5, Alternate2<Output>>;
-        const ALT: Alt = Alt::Alt1;
+        const ALT: Alt = Alt::Alt2;
     }
     impl PwmPeriph<CCR2> for Timer1A3 {
         type Gpio = Pin<P1, Pin4, Alternate2<Output>>;
-        const ALT: Alt = Alt::Alt1;
+        const ALT: Alt = Alt::Alt2;
     }
 
     // TA2

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -696,6 +696,13 @@ mod ehal1 {
         fn is_set_low(&mut self) -> Result<bool, Self::Error> {
             self.is_set_high().map(|r| !r)
         }
+
+        #[inline]
+        fn toggle(&mut self) -> Result<(), Self::Error> {
+            let p = unsafe { PORT::steal() };
+            p.pxout_toggle(PIN::SET_MASK);
+            Ok(())
+        }
     }
 }
 

--- a/hal/src/i2c.rs
+++ b/hal/src/i2c.rs
@@ -1229,6 +1229,7 @@ macro_rules! impl_i2c_error {
 /// If this originated from a blocking method the byte number counts up from the beginning of the transaction 
 /// (i.e. the initial start condition) where byte 0 is the address byte, byte 1 is the first data byte, etc.. 
 /// If it originated from a non-blocking method it counts up from the most recent Start or Repeated Start condition.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug)]
 pub enum NackType {
     /// Received a NACK during an address byte. No device with the specified address is on the bus.
@@ -1239,6 +1240,7 @@ pub enum NackType {
 }
 
 /// I2C transmit/receive errors on a single master I2C bus.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum I2cSingleMasterErr {
@@ -1249,6 +1251,7 @@ pub enum I2cSingleMasterErr {
 impl_i2c_error!(I2cSingleMasterErr);
 
 /// I2C transmit/receive errors on a multi-master I2C bus.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum I2cMultiMasterErr {
@@ -1263,6 +1266,7 @@ pub enum I2cMultiMasterErr {
 impl_i2c_error!(I2cMultiMasterErr);
 
 /// I2C transmit/receive errors on a master-slave I2C device.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum I2cMasterSlaveErr {

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -1,11 +1,15 @@
-//! Implementation of [`embedded_hal`] traits for MSP430FR2x5x family of microcontrollers.
-//! Here are the [`datasheet`] and [`User's guide`] for reference.
+//! A collection of peripheral drivers for the [MSP430FR2xxx/4xxx](http://www.ti.com/lit/ug/slau445i/slau445i.pdf) 
+//! family of microcontrollers with implementations of [`embedded_hal`] traits.
 //!
-//! As of this writing, the only supported MCUs are the MSP430FR2x5x series.
-//!
+//! As of this writing, the only supported MCUs are the MSP430FR2x5x series and the MSP430FR2433.
+//! Support for more devices is welcome. See the readme in the repository for information about how to 
+//! add support for a new device.
+//! 
+//! The documentation on docs.rs is built for the MSP430FR2355. To build the documentation for your device instead,
+//! add this crate as a dependency to your project (see: [Feature Flags](#feature-flags)) then run `cargo doc --open --package msp430fr2x5x-hal`.
+//! The repository contains such projects for various devices under `device_examples/`.
+//! 
 //! [`embedded_hal`]: https://github.com/rust-embedded/embedded-hal
-//! [`datasheet`]: http://www.ti.com/lit/ds/symlink/msp430fr2355.pdf
-//! [`User's guide`]: http://www.ti.com/lit/ug/slau445i/slau445i.pdf
 //!
 //! # Usage
 //!
@@ -16,8 +20,8 @@
 //!
 //! # Examples
 //!
-//! The `device-examples/` directory contains projects for various supported devices, each containing a typical project structure and 
-//! a number of examples that show how to use the HAL abstractions. These examples typically target the relevant dev board, 
+//! The `device-examples/` directory in the repository contains projects for various supported devices, each containing a typical 
+//! project structure and a number of examples that show how to use the HAL abstractions. These examples typically target the relevant dev board, 
 //! such as the MSP-EXP430FR2355 for the MSP430FR2355.
 //! 
 //! To flash the examples, make sure you have `mspdebug` with `tilib` support installed and in

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -39,6 +39,8 @@
 //! match crates that require the pre-1.0 version with those that require the latest version. It isn't enabled by
 //! default, as many of the trait names are similar (or identical) to their counterparts in the current
 //! version, which can be confusing.
+//! 
+//! Support for defmt is available behind the `defmt` feature.
 
 #![no_std]
 #![allow(incomplete_features)] // Enable specialization without warnings

--- a/hal/src/serial.rs
+++ b/hal/src/serial.rs
@@ -24,6 +24,7 @@ use crate::clock::{Aclk, Clock, Smclk};
 use crate::hw_traits::eusci::{EUsciUart, UartUcxStatw, UcaCtlw0, Ucssel};
 use crate::pin_mapping::*;
 use core::convert::Infallible;
+use core::fmt::Display;
 use core::marker::PhantomData;
 use core::num::NonZeroU32;
 
@@ -567,6 +568,7 @@ where
 }
 
 /// Serial receive errors
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug)]
 pub enum RecvError {
     /// Framing error
@@ -576,6 +578,13 @@ pub enum RecvError {
     /// Buffer overrun error. Contains the most recently read byte, which is still valid.
     Overrun(u8),
 }
+// embedded-io requires this
+impl Display for RecvError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl core::error::Error for RecvError {}
 
 mod emb_io {
     use super::*;

--- a/hal/src/spi.rs
+++ b/hal/src/spi.rs
@@ -379,6 +379,7 @@ where
 }
 
 /// SPI transmit/receive errors
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug)]
 pub enum SpiErr {
     /// Data in the recieve buffer was overwritten before it was read. The contained data is the new contents of the recieve buffer.


### PR DESCRIPTION
Updates the changelog and docs for the previous PR.

Added defmt support with an example program. I initially avoided defmt on the MSP since all the provided defmt backends like RTT didn't work with it, but I recently wrote a big program for the MSP and needed the space savings. I found a defmt-over-serial crate which works well. The implementation on the library end is basically just deriving the defmt macro on error types so they can be printed in the case of a panic. I had to bump `embedded-io` in the process, which in turn requires we now implement `Display` for `RecvError`.

I noticed that the default implementation of ehal's GPIO toggle reads the GPIO then either sets or clears the bit respectively. We can do this in one operation with our atomic bit toggling. Using the default clock configuration this custom implementation increases the maximum GPIO toggle speed from ~335kHz to ~574kHz.

Fixes the bug mentioned in #41.