### PR TITLE
XT1 Clock Implementation and RTC Source Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ To add support for a device (or subfamily) you should fork this repo and:
 # Functionality
 The library is mostly feature complete for the MSP430FR2x5x subfamily. There are a few edge cases not yet supported, such as:
 - Arbitrary DCO clock speed support (currently supports 1, 2, 4, 8, 12, 16, 20, 24 MHz)
-- External oscillator support
-- Some RTC clock sources (currently only supports SMCLK and VLOCLK)
 - ADC reference voltage selection
 
 If you encounter any use cases not supported please open an issue (or submit a pull request).

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -24,8 +24,8 @@ msp430fr2475 = ["247x"]           # 6kB RAM
 msp430fr2476 = ["247x"]           # 8kB RAM
 
 # Derived features. Do not provide these.
-2x5x = ["dep:msp430fr2355", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "ecomp", "eusci_b", "vloclk_source"]
-247x = ["dep:msp430fr247x", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "ecomp", "eusci_b", "vloclk_source"]
+2x5x = ["dep:msp430fr2355", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "ecomp", "eusci_b", "vloclk_source", "xt1_high_frequency", "enhanced_cs", "rtc_aclk"]
+247x = ["dep:msp430fr247x", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "ecomp", "eusci_b", "vloclk_source", "rtc_aclk"]
 eusci_aclk = [] # eUSCI peripherals can source from ACLK
 eusci_modclk = [] # eUSCI peripherals can source from MODCLK
 adc12bit = ["adc"]
@@ -40,6 +40,9 @@ sac = []
 tia = []
 info_mem = []
 vloclk_source = []
+xt1_high_frequency = []
+enhanced_cs = []
+rtc_aclk = []
 
 [dependencies]
 msp430 = "0.4.0"

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -504,8 +504,8 @@ impl<MCLK, SMCLK, XT1CLK> ClockConfig<MCLK, SMCLK, XT1CLK> {
 impl<MCLK, SMCLK, MODE> ClockConfig<MCLK, SMCLK, Xt1Defined<MODE>> {
     /// Select XT1CLK for ACLK
     #[inline]
-    pub fn aclk_xt1clk(mut self, freq: u32) -> Self {
-        self.aclk_sel = AclkSel::Xt1clk(freq);
+    pub fn aclk_xt1clk(mut self) -> Self {
+        self.aclk_sel = AclkSel::Xt1clk(self.xt1clk.freq());
         self
     }
 

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -551,6 +551,7 @@ impl<SMCLK: SmclkState, XT1CLK: Xt1State> ClockConfig<MclkDefined, SMCLK, XT1CLK
             // hardware dividers. Each cutoff (1.5MHz, 3MHz, etc.) ensures the 
             // resulting FLL reference stays within the stable ~23kHz to ~47kHz range.
             let (ref_freq, ref_div) = match self.fll_ref {
+                #[cfg(not(any(feature = "msp430fr2433")))]
                 Selref::Xt1clk => {
                     let freq = self.xt1clk.freq();
                     if freq <= 40_000 { 
@@ -588,7 +589,34 @@ impl<SMCLK: SmclkState, XT1CLK: Xt1State> ClockConfig<MclkDefined, SMCLK, XT1CLK
                         }
                     }
                 }
+                #[cfg(not(any(feature = "msp430fr2433")))]
                 _ => (REFOCLK_FREQ_HZ as u32, Fllrefdiv::_1),
+                #[cfg(any(feature = "msp430fr2433"))]
+                Selref::Xt1clk => {
+                    let freq = self.xt1clk.freq();
+                    if freq <= 40_000 {
+                        // Standard 32.768kHz crystal
+                        (freq, Fllrefdiv::Fllrefdiv0)
+                    } else if freq <= 80_000 {
+                        // 80kHz / 2 = 40kHz
+                        (freq / 2, Fllrefdiv::Fllrefdiv1)
+                    } else if freq <= 160_000 {
+                        // 160kHz / 4 = 40kHz
+                        (freq / 4, Fllrefdiv::Fllrefdiv2)
+                    } else if freq <= 320_000 {
+                        // 320kHz / 8 = 40kHz
+                        (freq / 8, Fllrefdiv::Fllrefdiv3)
+                    } else if freq <= 480_000 {
+                        // 480kHz / 12 = 40kHz
+                        (freq / 12, Fllrefdiv::Fllrefdiv4)
+                    } else {
+                        // Max divider is /16. 
+                        // If user provides a 1MHz signal, ref = 62.5kHz (Risky/Out of spec!)
+                        (freq / 16, Fllrefdiv::Fllrefdiv5)
+                    }
+                }
+                #[cfg(any(feature = "msp430fr2433"))]
+                _ => (REFOCLK_FREQ_HZ as u32, Fllrefdiv::Fllrefdiv0),
             };
 
             fll_off();

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -1,19 +1,35 @@
-//! Clock system for configuration of MCLK, SMCLK, and ACLK.
+//! Clock system for configuration of MCLK, SMCLK, ACLK, and XT1.
 //!
-//! Once configuration is complete, `Aclk` and `Smclk` clock objects are returned. The clock
-//! objects are used to set the clock sources on other peripherals.
-//! Configuration of MCLK and SMCLK *must* occur, though SMCLK can be disabled. In that case, only
-//! `Aclk` is returned.
+//! Once configuration is complete, `Aclk`, `Smclk`, and optionally `Xt1clk` clock objects 
+//! are returned. These objects are used to set the clock sources on other peripherals.
 //!
-//! DCO with FLL is supported on MCLK for select frequencies. Supporting arbitrary frequencies on
-//! the DCO requires complex calibration routines not supported by the HAL.
+//! Configuration of MCLK and SMCLK *must* occur, though SMCLK can be disabled. XT1 
+//! configuration is optional but, when enabled, provides a high-precision source for 
+//! system clocks or the FLL reference.
+//!
+//! DCO with FLL is supported on MCLK for select frequencies. The FLL can be 
+//! referenced by either the internal REFO or the external XT1 crystal. Supporting 
+//! arbitrary frequencies on the DCO requires complex calibration routines not 
+//! supported by the HAL.
 
 use core::arch::asm;
+use core::marker::PhantomData;
 
 use crate::delay::SysDelay;
 use crate::fram::{Fram, WaitStates};
-use crate::_pac::{self, cs::{csctl1::Dcorsel, csctl4::{Sela, Selms}}};
+use crate::_pac::{
+    self,
+    cs::{
+        csctl1::Dcorsel,
+        csctl4::{Sela, Selms},
+        csctl3::{Selref, Fllrefdiv},
+        csctl6::Xt1drive,
+    },
+};
 pub use crate::_pac::cs::csctl5::{Divm as MclkDiv, Divs as SmclkDiv};
+
+#[cfg(feature = "xt1_high_frequency")]
+use crate::_pac::cs::csctl6::{Xt1hffreq, Xts};
 
 /// REFOCLK frequency
 pub const REFOCLK_FREQ_HZ: u16 = 32768;
@@ -25,6 +41,7 @@ enum MclkSel {
     Refoclk,
     Vloclk,
     Dcoclk(DcoclkFreqSel),
+    Xt1clk(u32),
 }
 
 impl MclkSel {
@@ -34,6 +51,7 @@ impl MclkSel {
             MclkSel::Vloclk => VLOCLK_FREQ_HZ as u32,
             MclkSel::Refoclk => REFOCLK_FREQ_HZ as u32,
             MclkSel::Dcoclk(sel) => sel.freq(),
+            MclkSel::Xt1clk(freq) => *freq,
         }
     }
 
@@ -43,6 +61,7 @@ impl MclkSel {
             MclkSel::Vloclk => Selms::Vloclk,
             MclkSel::Refoclk => Selms::Refoclk,
             MclkSel::Dcoclk(_) => Selms::Dcoclkdiv,
+            MclkSel::Xt1clk(_) => Selms::Xt1clk,
         }
     }
 }
@@ -52,7 +71,7 @@ enum AclkSel {
     #[cfg(feature = "vloclk_source")]
     Vloclk,
     Refoclk,
-    // TODO: XT1CLK
+    Xt1clk(u32),
 }
 
 impl AclkSel {
@@ -62,15 +81,17 @@ impl AclkSel {
             #[cfg(feature = "vloclk_source")]
             AclkSel::Vloclk => Sela::Vloclk,
             AclkSel::Refoclk => Sela::Refoclk,
+            AclkSel::Xt1clk(_) => Sela::Xt1clk,
         }
     }
 
     #[inline(always)]
-    fn freq(self) -> u16 {
+    fn freq(self) -> u32 {
         match self {
             #[cfg(feature = "vloclk_source")]
-            AclkSel::Vloclk => VLOCLK_FREQ_HZ,
-            AclkSel::Refoclk => REFOCLK_FREQ_HZ,
+            AclkSel::Vloclk => VLOCLK_FREQ_HZ as u32,
+            AclkSel::Refoclk => REFOCLK_FREQ_HZ as u32,
+            AclkSel::Xt1clk(freq) => freq,
         }
     }
 }
@@ -91,10 +112,10 @@ pub enum DcoclkFreqSel {
     _12MHz,
     /// 16 MHz
     _16MHz,
-    #[cfg(feature = "2x5x")]
+    #[cfg(feature = "enhanced_cs")]
     /// 20 MHz
     _20MHz,
-    #[cfg(feature = "2x5x")]
+    #[cfg(feature = "enhanced_cs")]
     /// 24 MHz
     _24MHz,
 }
@@ -109,9 +130,9 @@ impl DcoclkFreqSel {
             DcoclkFreqSel::_8MHz => Dcorsel::Dcorsel3,
             DcoclkFreqSel::_12MHz => Dcorsel::Dcorsel4,
             DcoclkFreqSel::_16MHz => Dcorsel::Dcorsel5,
-            #[cfg(feature = "2x5x")]
+            #[cfg(feature = "enhanced_cs")]
             DcoclkFreqSel::_20MHz => Dcorsel::Dcorsel6,
-            #[cfg(feature = "2x5x")]
+            #[cfg(feature = "enhanced_cs")]
             DcoclkFreqSel::_24MHz => Dcorsel::Dcorsel7,
         }
     }
@@ -125,9 +146,9 @@ impl DcoclkFreqSel {
             DcoclkFreqSel::_8MHz => 245,
             DcoclkFreqSel::_12MHz => 366,
             DcoclkFreqSel::_16MHz => 490,
-            #[cfg(feature = "2x5x")]
+            #[cfg(feature = "enhanced_cs")]
             DcoclkFreqSel::_20MHz => 610,
-            #[cfg(feature = "2x5x")]
+            #[cfg(feature = "enhanced_cs")]
             DcoclkFreqSel::_24MHz => 732,
         }
     }
@@ -147,6 +168,195 @@ pub struct MclkDefined(MclkSel);
 pub struct SmclkDefined(SmclkDiv);
 /// Typestate for `ClockConfig` that represents disabled SMCLK
 pub struct SmclkDisabled;
+/// Typestate for `ClockConfig` that represents a configured XT1CLK
+pub struct Xt1Defined<MODE>(Xt1Config<MODE>);
+/// Typestate for `ClockConfig` that represents disabled/unconfigured XT1CLK
+pub struct Xt1Disabled;
+
+
+/// Valid XT1 XIN (input) pin
+pub trait Xt1XinPin {}
+
+/// Valid XT1 XOUT (output) pin
+pub trait Xt1XoutPin {}
+
+
+/// Typestate marker for XT1 **crystal mode** (external crystal, oscillator enabled).
+pub struct CrystalMode;
+
+/// Typestate marker for XT1 **bypass mode** (external clock input, oscillator disabled).
+pub struct BypassMode;
+
+/// Configuration object for the XT1 oscillator.
+///
+/// This struct defines how the XT1 clock source should be initialized when
+/// applying the clock configuration via [`ClockConfig::xt1clk_on`].
+///
+/// XT1 can operate in two modes:
+///
+/// - **Crystal mode**: Uses an external crystal connected to both XIN and XOUT.
+/// - **Bypass mode**: Uses an external clock signal fed into XIN only.
+///
+/// The configuration includes:
+/// - The input frequency (used for timing calculations and routing decisions)
+/// - Drive strength for the oscillator (relevant in crystal mode)
+/// - Whether bypass mode is enabled
+/// - Automatic Gain Control (AGC) behavior
+pub struct Xt1Config<MODE> {
+    frequency: u32,
+    drive: Xt1drive,
+    agc: bool,
+    start_counter: bool,
+    bypass: bool,
+    #[cfg(feature = "enhanced_cs")]
+    fault_switch: bool,
+    auto_off: bool,
+    _mode: PhantomData<MODE>,
+}
+
+#[cfg(feature = "enhanced_cs")]
+impl<MODE> Xt1Config<MODE> {
+    /// Disable the automatic clock fallback on XT1 fault.
+    ///
+    /// When disabled, the system will not automatically switch to a fallback 
+    /// oscillator (like REFO) if the XT1 crystal fails or stops.
+    pub fn disable_fault_switch(mut self) -> Self {
+        self.fault_switch = false;
+        self
+    }
+}
+
+impl Xt1Config<CrystalMode> {
+    /// Configure XT1 as a crystal oscillator.
+    ///
+    /// This mode expects a crystal connected to XIN/XOUT and enables
+    /// internal oscillator circuitry.
+    ///
+    /// - `frequency`: Target crystal frequency in Hz.
+    /// - `_xin`, `_xout`: Pins connected to the crystal.
+    ///
+    /// The start counter is enabled by default in crystal mode because
+    /// crystals require a stabilization period before producing a valid clock.
+    /// The counter ensures the oscillator is given sufficient startup time
+    /// before being considered stable.
+    pub fn crystal<XIN, XOUT>(frequency: u32, _xin: XIN, _xout: XOUT) -> Self
+    where
+        XIN: Xt1XinPin,
+        XOUT: Xt1XoutPin,
+    {
+        // Enforce crystal frequency limits (32kHz typical, up to 24MHz on some MCUs)
+        Self {
+            frequency,
+            drive: Xt1drive::Xt1drive3,
+            agc: false,
+            start_counter: true, // Required for crystal startup stabilization
+            bypass: false,
+            #[cfg(feature = "enhanced_cs")]
+            fault_switch: true,
+            auto_off: true,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Enable Automatic Gain Control (AGC).
+    ///
+    /// AGC is only applicable in crystal mode and helps stabilize oscillation
+    /// amplitude across varying conditions.
+    pub fn enable_agc(mut self) -> Self {
+        self.agc = true;
+        self
+    }
+
+    /// Set oscillator drive strength.
+    ///
+    /// Higher drive strength may be required for higher-frequency crystals
+    /// or specific load conditions.
+    pub fn with_drive(mut self, drive: Xt1drive) -> Self {
+        self.drive = drive;
+        self
+    }
+
+    /// Disable the startup counter.
+    ///
+    /// This skips the oscillator stabilization wait period. Only disable this
+    /// if startup timing is externally managed or guaranteed, as doing so may
+    /// result in using an unstable clock.
+    pub fn disable_start_counter(mut self) -> Self {
+        self.start_counter = false;
+        self
+    }
+
+    /// Disable automatic crystal power-down.
+    ///
+    /// Setting this to false ensures XT1 remains active even if it is not 
+    /// currently requested by a system clock (ACLK, MCLK, SMCLK) or the FLL.
+    pub fn disable_auto_off(mut self) -> Self {
+        self.auto_off = false;
+        self
+    }
+}
+
+impl Xt1Config<BypassMode> {
+    /// Configure XT1 in bypass mode using an external clock source.
+    ///
+    /// In this mode, a digital clock signal is fed directly into XIN and the
+    /// internal crystal oscillator circuitry is bypassed.
+    ///
+    /// - `frequency`: Input clock frequency in Hz.
+    /// - `_xin`: Pin receiving the external clock.
+    ///
+    /// The start counter is disabled by default because an external clock
+    /// source is assumed to already be stable and does not require oscillator
+    /// startup time.
+    pub fn bypass<XIN>(frequency: u32, _xin: XIN) -> Self
+    where
+        XIN: Xt1XinPin,
+    {
+        // Frequency limits depend on MCU family:
+        // - Some devices: max ~1MHz
+        // - Others (e.g. FR2355): up to 24MHz
+        Self {
+            frequency,
+            drive: Xt1drive::Xt1drive0, // Ignored in bypass mode
+            agc: false,              // Not applicable in bypass mode
+            start_counter: false,    // External clock assumed stable
+            bypass: true,
+            #[cfg(feature = "enhanced_cs")]
+            fault_switch: true,
+            auto_off: true,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Enable the startup counter.
+    ///
+    /// This is typically unnecessary in bypass mode, but may be useful if the
+    /// external clock source has a delayed or uncertain startup behavior and
+    /// additional stabilization time is required.
+    pub fn enable_start_counter(mut self) -> Self {
+        self.start_counter = true;
+        self
+    }
+}
+
+#[doc(hidden)]
+pub trait Xt1State {
+    fn freq(&self) -> u32;
+}
+
+impl<MODE> Xt1State for Xt1Defined<MODE> {
+    #[inline(always)]
+    fn freq(&self) -> u32 {
+        self.0.frequency
+    }
+}
+
+impl Xt1State for Xt1Disabled {
+    #[inline(always)]
+    fn freq(&self) -> u32 {
+        0 // Or REFOCLK_FREQ_HZ if you want a fallback, but 0 is safer for debugging
+    }
+}
 
 // Using SmclkState as a trait bound outside the HAL will never be useful, since we only configure
 // the clock once, so just keep it hidden
@@ -173,40 +383,46 @@ impl SmclkState for SmclkDisabled {
 ///
 /// Can only commit configurations to hardware if both MCLK and SMCLK settings have been
 /// configured. ACLK configurations are optional, with its default source being REFOCLK.
-pub struct ClockConfig<MCLK, SMCLK> {
+pub struct ClockConfig<MCLK, SMCLK, XT1CLK> {
     periph: _pac::Cs,
     mclk: MCLK,
     mclk_div: MclkDiv,
     aclk_sel: AclkSel,
     smclk: SMCLK,
+    xt1clk: XT1CLK,
+    fll_ref: Selref
 }
 
 macro_rules! make_clkconf {
-    ($conf:expr, $mclk:expr, $smclk:expr) => {
+    ($conf:expr, $mclk:expr, $smclk:expr, $xt1clk:expr) => {
         ClockConfig {
             periph: $conf.periph,
             mclk: $mclk,
             mclk_div: $conf.mclk_div,
             aclk_sel: $conf.aclk_sel,
             smclk: $smclk,
+            xt1clk: $xt1clk,
+            fll_ref: Selref::Refoclk,
         }
     };
 }
 
-impl ClockConfig<NoClockDefined, NoClockDefined> {
+impl ClockConfig<NoClockDefined, NoClockDefined, Xt1Disabled> {
     /// Converts CS into a fresh, unconfigured clock builder object
     pub fn new(cs: _pac::Cs) -> Self {
         ClockConfig {
             periph: cs,
             smclk: NoClockDefined,
             mclk: NoClockDefined,
+            xt1clk: Xt1Disabled,
             mclk_div: MclkDiv::_1,
             aclk_sel: AclkSel::Refoclk,
+            fll_ref: Selref::Refoclk,
         }
     }
 }
 
-impl<MCLK, SMCLK> ClockConfig<MCLK, SMCLK> {
+impl<MCLK, SMCLK, XT1CLK> ClockConfig<MCLK, SMCLK, XT1CLK> {
     /// Select REFOCLK for ACLK
     #[inline]
     pub fn aclk_refoclk(mut self) -> Self {
@@ -224,19 +440,19 @@ impl<MCLK, SMCLK> ClockConfig<MCLK, SMCLK> {
 
     /// Select REFOCLK for MCLK and set the MCLK divider. Frequency is `32_768 / mclk_div` Hz.
     #[inline]
-    pub fn mclk_refoclk(self, mclk_div: MclkDiv) -> ClockConfig<MclkDefined, SMCLK> {
+    pub fn mclk_refoclk(self, mclk_div: MclkDiv) -> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Refoclk), self.smclk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Refoclk), self.smclk, self.xt1clk)
         }
     }
 
     /// Select VLOCLK for MCLK and set the MCLK divider. Frequency is `10_000 / mclk_div` Hz.
     #[inline]
-    pub fn mclk_vloclk(self, mclk_div: MclkDiv) -> ClockConfig<MclkDefined, SMCLK> {
+    pub fn mclk_vloclk(self, mclk_div: MclkDiv) -> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Vloclk), self.smclk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Vloclk), self.smclk, self.xt1clk)
         }
     }
 
@@ -248,23 +464,69 @@ impl<MCLK, SMCLK> ClockConfig<MCLK, SMCLK> {
         self,
         target_freq: DcoclkFreqSel,
         mclk_div: MclkDiv,
-    ) -> ClockConfig<MclkDefined, SMCLK> {
+    ) -> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Dcoclk(target_freq)), self.smclk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Dcoclk(target_freq)), self.smclk, self.xt1clk)
         }
     }
 
     /// Enable SMCLK and set SMCLK divider, which divides the MCLK frequency
     #[inline]
-    pub fn smclk_on(self, div: SmclkDiv) -> ClockConfig<MCLK, SmclkDefined> {
-        make_clkconf!(self, self.mclk, SmclkDefined(div))
+    pub fn smclk_on(self, div: SmclkDiv) -> ClockConfig<MCLK, SmclkDefined, XT1CLK> {
+        make_clkconf!(self, self.mclk, SmclkDefined(div), self.xt1clk)
     }
 
     /// Disable SMCLK
     #[inline]
-    pub fn smclk_off(self) -> ClockConfig<MCLK, SmclkDisabled> {
-        make_clkconf!(self, self.mclk, SmclkDisabled)
+    pub fn smclk_off(self) -> ClockConfig<MCLK, SmclkDisabled, XT1CLK> {
+        make_clkconf!(self, self.mclk, SmclkDisabled, self.xt1clk)
+    }
+
+    /// Enable XT1 with specific hardware requirements
+    #[inline]
+    pub fn xt1clk_on<MODE>(
+        self, 
+        config: Xt1Config<MODE>
+    ) -> ClockConfig<MCLK, SMCLK, Xt1Defined<MODE>> {
+        // Here you would write to the CSCTL registers 
+        // using the values inside `config`
+        make_clkconf!(self, self.mclk, self.smclk, Xt1Defined(config))
+    }
+
+    /// Explicitly disable XT1 to save power
+    #[inline]
+    pub fn xt1clk_off(self) -> ClockConfig<MCLK, SMCLK, Xt1Disabled> {
+        make_clkconf!(self, self.mclk, self.smclk, Xt1Disabled)
+    }
+}
+
+impl<MCLK, SMCLK, MODE> ClockConfig<MCLK, SMCLK, Xt1Defined<MODE>> {
+    /// Select XT1CLK for ACLK
+    #[inline]
+    pub fn aclk_xt1clk(mut self, freq: u32) -> Self {
+        self.aclk_sel = AclkSel::Xt1clk(freq);
+        self
+    }
+
+    /// Select XT1CLK for MCLK
+    #[inline]
+    pub fn mclk_xt1clk(
+        self,
+        mclk_div: MclkDiv,
+    ) -> ClockConfig<MclkDefined, SMCLK, Xt1Defined<MODE>> {
+        let freq = self.xt1clk.0.frequency;
+        ClockConfig {
+            mclk_div,
+            ..make_clkconf!(self, MclkDefined(MclkSel::Xt1clk(freq)), self.smclk, self.xt1clk)
+        }
+    }
+
+    /// Select XT1CLK for fll
+    #[inline]
+    pub fn fll_ref_xt1(mut self) -> Self  {
+        self.fll_ref = Selref::Xt1clk;
+        self
     }
 }
 
@@ -280,20 +542,69 @@ fn fll_on() {
     unsafe { asm!("bic.b #64, SR", options(nomem, nostack)) };
 }
 
-impl<SMCLK: SmclkState> ClockConfig<MclkDefined, SMCLK> {
+impl<SMCLK: SmclkState, XT1CLK: Xt1State> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
     #[inline]
     fn configure_dco_fll(&self) {
         // Run FLL configuration procedure from the user's guide if we are using DCO
         if let MclkSel::Dcoclk(target_freq) = self.mclk.0 {
+            // These thresholds are calculated as the "handover" points between 
+            // hardware dividers. Each cutoff (1.5MHz, 3MHz, etc.) ensures the 
+            // resulting FLL reference stays within the stable ~23kHz to ~47kHz range.
+            let (ref_freq, ref_div) = match self.fll_ref {
+                Selref::Xt1clk => {
+                    let freq = self.xt1clk.freq();
+                    if freq <= 40_000 { 
+                        (freq, Fllrefdiv::_1) 
+                    } else if freq <= 1_500_000 { 
+                        // Divider handover: at 1.5MHz, /32 is 46.8kHz, /64 is 23.4kHz.
+                        (freq / 32, Fllrefdiv::_32) 
+                    } else if freq <= 3_000_000 { 
+                        // Divider handover: at 3.0MHz, /64 is 46.8kHz, /128 is 23.4kHz.
+                        (freq / 64, Fllrefdiv::_64) 
+                    } else if freq <= 6_000_000 { 
+                        // Divider handover: at 6.0MHz, /128 is 46.8kHz, /256 is 23.4kHz.
+                        (freq / 128, Fllrefdiv::_128) 
+                    } else if freq <= 12_000_000 { 
+                        // Divider handover: at 12.0MHz, /256 is 46.8kHz, /512 is 23.4kHz.
+                        (freq / 256, Fllrefdiv::_256) 
+                    } else if freq <= 18_000_000 { 
+                        // Max standard divider is /512. At 18MHz, ref is 35.1kHz.
+                        (freq / 512, Fllrefdiv::_512) 
+                    } else {
+                        // TODO: make Fllrefdiv same across pacs
+                        #[cfg(feature = "enhanced_cs")]
+                        {
+                            if freq <= 22_000_000 {
+                                // Handover to /640 for 24MHz capable systems.
+                                (freq / 640, Fllrefdiv::Fllrefdiv6)
+                            } else {
+                                // Handover to /768 to keep 24MHz crystal at 31.25kHz ref.
+                                (freq / 768, Fllrefdiv::Fllrefdiv7)
+                            }
+                        }
+                        #[cfg(not(feature = "enhanced_cs"))]
+                        {
+                            (freq / 512, Fllrefdiv::_512)
+                        }
+                    }
+                }
+                _ => (REFOCLK_FREQ_HZ as u32, Fllrefdiv::_1),
+            };
+
             fll_off();
 
-            self.periph.csctl3().write(|w| w.selref().refoclk());
+            self.periph.csctl3()
+                .write(|w| w.selref().variant(self.fll_ref).fllrefdiv().variant(ref_div));
             self.periph.csctl0().write(|w| unsafe { w.bits(0) });
             self.periph
                 .csctl1()
                 .write(|w| w.dcorsel().variant(target_freq.dcorsel()));
+
+            // Use the calculated ref_freq to get a precise multiplier
+            let multiplier = (target_freq.freq() / ref_freq) as u16;
+
             self.periph.csctl2().write(|w| {
-                unsafe { w.flln().bits(target_freq.multiplier() - 1) }
+                unsafe { w.flln().bits(multiplier - 1) }
                     .flld()
                     ._1()
             });
@@ -339,7 +650,85 @@ impl<SMCLK: SmclkState> ClockConfig<MclkDefined, SMCLK> {
     }
 }
 
-impl ClockConfig<MclkDefined, SmclkDefined> {
+impl<SMCLK: SmclkState, MCLK, MODE> ClockConfig<MCLK, SMCLK, Xt1Defined<MODE>> {
+    #[inline]
+    fn configure_xt1(&self) {
+        let cfg = &self.xt1clk.0;
+        let sfr = unsafe { &*_pac::Sfr::ptr() };
+        
+        self.periph.csctl6().modify(|_, w| {
+            #[cfg(feature = "xt1_high_frequency")]
+            {
+                let (xts, hf_range) = if cfg.frequency <= 40_000 {
+                    (Xts::Xts0, Xt1hffreq::Xt1hffreq0)
+                } else if cfg.frequency <= 4_000_000 {
+                    (Xts::Xts1, Xt1hffreq::Xt1hffreq0)
+                } else if cfg.frequency <= 6_000_000 {
+                    (Xts::Xts1, Xt1hffreq::Xt1hffreq1)
+                } else if cfg.frequency <= 16_000_000 {
+                    (Xts::Xts1, Xt1hffreq::Xt1hffreq2)
+                } else {
+                    (Xts::Xts1, Xt1hffreq::Xt1hffreq3)
+                };
+                
+                w.xt1bypass().bit(cfg.bypass)
+                 .xt1faultoff().bit(!cfg.fault_switch)
+                 .xts().variant(xts)
+                 .xt1agcoff().bit(!cfg.agc)
+                 .xt1autooff().bit(cfg.auto_off)
+                 .xt1hffreq().variant(hf_range)
+            }
+
+            #[cfg(not(feature = "xt1_high_frequency"))]
+            {        
+                w.xt1bypass().bit(cfg.bypass)
+                 .xts().clear_bit()
+                 .xt1agcoff().bit(!cfg.agc)
+                 .xt1autooff().bit(cfg.auto_off)
+            }
+        });
+
+        self.periph.csctl7().modify(|_, w| w.enstfcnt1().bit(cfg.start_counter));
+
+        loop {
+            unsafe {
+                self.periph.csctl7().clear_bits(|w| 
+                    w.xt1offg().clear_bit()
+                      .dcoffg().clear_bit()
+                );
+                sfr.sfrifg1().clear_bits(|w| w.ofifg().clear_bit());
+            }
+
+            // Poll global fault flag
+            if sfr.sfrifg1().read().ofifg().bit_is_clear() {
+                break;
+            }
+        }
+
+        self.periph.csctl6().modify(|_, w| { w.xt1drive().variant(cfg.drive) });
+    }
+}
+
+impl<MODE> ClockConfig<MclkDefined, SmclkDefined, Xt1Defined<MODE>> {
+    /// Apply clock configuration to hardware and return SMCLK and ACLK clock objects.
+    /// Also returns delay provider
+    #[inline]
+    pub fn freeze(self, fram: &mut Fram) -> (Smclk, Aclk, Xt1clk, SysDelay) {
+        let mclk_freq = self.mclk.0.freq() >> (self.mclk_div as u32);
+        unsafe { Self::configure_fram(fram, mclk_freq) };
+        self.configure_xt1();
+        self.configure_dco_fll();
+        self.configure_cs();
+        (
+            Smclk(mclk_freq >> (self.smclk.0 as u32)),
+            Aclk(self.aclk_sel.freq()),
+            Xt1clk(self.xt1clk.freq()),
+            SysDelay::new(mclk_freq),
+        )
+    }
+}
+
+impl ClockConfig<MclkDefined, SmclkDefined, Xt1Disabled> {
     /// Apply clock configuration to hardware and return SMCLK and ACLK clock objects.
     /// Also returns delay provider
     #[inline]
@@ -356,7 +745,25 @@ impl ClockConfig<MclkDefined, SmclkDefined> {
     }
 }
 
-impl ClockConfig<MclkDefined, SmclkDisabled> {
+impl<MODE> ClockConfig<MclkDefined, SmclkDisabled, Xt1Defined<MODE>> {
+    /// Apply clock configuration to hardware and return ACLK clock object, as SMCLK is disabled.
+    /// Also returns delay provider.
+    #[inline]
+    pub fn freeze(self, fram: &mut Fram) -> (Aclk, Xt1clk, SysDelay) {
+        let mclk_freq = self.mclk.0.freq() >> (self.mclk_div as u32);
+        unsafe { Self::configure_fram(fram, mclk_freq) };
+        self.configure_xt1();
+        self.configure_dco_fll();
+        self.configure_cs();
+        (
+            Aclk(self.aclk_sel.freq()), 
+            Xt1clk(self.xt1clk.freq()),
+            SysDelay::new(mclk_freq)
+        )
+    }
+}
+
+impl ClockConfig<MclkDefined, SmclkDisabled, Xt1Disabled> {
     /// Apply clock configuration to hardware and return ACLK clock object, as SMCLK is disabled.
     /// Also returns delay provider.
     #[inline]
@@ -372,24 +779,20 @@ impl ClockConfig<MclkDefined, SmclkDisabled> {
 /// SMCLK clock object
 pub struct Smclk(u32);
 /// ACLK clock object
-pub struct Aclk(u16);
+pub struct Aclk(u32);
+/// XT1CLK clock object
+pub struct Xt1clk(u32);
 
 /// Trait for configured clock objects
 pub trait Clock {
-    /// Type of the returned frequency value
-    type Freq;
-
-    /// Frequency of the clock
-    fn freq(&self) -> Self::Freq;
-}
-
-impl Clock for Smclk {
-    type Freq = u32;
-
     /// Returning a 32-bit frequency may seem suspect, since we're on a 16-bit system, but it is
     /// required as SMCLK can go up to 24 MHz. Clock frequencies are usually for initialization
     /// tasks such as computing baud rates, which should be optimized away, avoiding the extra cost
     /// of 32-bit computations.
+    fn freq(&self) -> u32;
+}
+
+impl Clock for Smclk {
     #[inline]
     fn freq(&self) -> u32 {
         self.0
@@ -397,10 +800,15 @@ impl Clock for Smclk {
 }
 
 impl Clock for Aclk {
-    type Freq = u16;
-
     #[inline]
-    fn freq(&self) -> u16 {
+    fn freq(&self) -> u32 {
+        self.0
+    }
+}
+
+impl Clock for Xt1clk {
+    #[inline]
+    fn freq(&self) -> u32 {
         self.0
     }
 }

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -249,7 +249,7 @@ impl Xt1Config<CrystalMode> {
             frequency,
             drive: Xt1drive::Xt1drive3,
             agc: false,
-            start_counter: true, // Required for crystal startup stabilization
+            start_counter: true,
             bypass: false,
             #[cfg(feature = "enhanced_cs")]
             fault_switch: true,
@@ -318,8 +318,8 @@ impl Xt1Config<BypassMode> {
         Self {
             frequency,
             drive: Xt1drive::Xt1drive0, // Ignored in bypass mode
-            agc: false,              // Not applicable in bypass mode
-            start_counter: false,    // External clock assumed stable
+            agc: false,                 // Not applicable in bypass mode
+            start_counter: false,       // External clock assumed stable
             bypass: true,
             #[cfg(feature = "enhanced_cs")]
             fault_switch: true,
@@ -353,10 +353,12 @@ impl<MODE> Xt1State for Xt1Defined<MODE> {
 
 impl Xt1State for Xt1Disabled {
     #[inline(always)]
+    // Unreachanble freq() only called when self.fll_ref is Xt1clk and that is only possble when Xt1 is defined
     fn freq(&self) -> u32 {
-        0 // Or REFOCLK_FREQ_HZ if you want a fallback, but 0 is safer for debugging
+        unreachable!() 
     }
 }
+
 
 // Using SmclkState as a trait bound outside the HAL will never be useful, since we only configure
 // the clock once, so just keep it hidden
@@ -394,7 +396,7 @@ pub struct ClockConfig<MCLK, SMCLK, XT1CLK> {
 }
 
 macro_rules! make_clkconf {
-    ($conf:expr, $mclk:expr, $smclk:expr, $xt1clk:expr) => {
+    ($conf:expr, $mclk:expr, $smclk:expr, $xt1clk:expr, $fll_ref: expr) => {
         ClockConfig {
             periph: $conf.periph,
             mclk: $mclk,
@@ -402,7 +404,7 @@ macro_rules! make_clkconf {
             aclk_sel: $conf.aclk_sel,
             smclk: $smclk,
             xt1clk: $xt1clk,
-            fll_ref: Selref::Refoclk,
+            fll_ref: $fll_ref,
         }
     };
 }
@@ -443,7 +445,7 @@ impl<MCLK, SMCLK, XT1CLK> ClockConfig<MCLK, SMCLK, XT1CLK> {
     pub fn mclk_refoclk(self, mclk_div: MclkDiv) -> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Refoclk), self.smclk, self.xt1clk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Refoclk), self.smclk, self.xt1clk, self.fll_ref)
         }
     }
 
@@ -452,7 +454,7 @@ impl<MCLK, SMCLK, XT1CLK> ClockConfig<MCLK, SMCLK, XT1CLK> {
     pub fn mclk_vloclk(self, mclk_div: MclkDiv) -> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Vloclk), self.smclk, self.xt1clk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Vloclk), self.smclk, self.xt1clk, self.fll_ref)
         }
     }
 
@@ -467,20 +469,20 @@ impl<MCLK, SMCLK, XT1CLK> ClockConfig<MCLK, SMCLK, XT1CLK> {
     ) -> ClockConfig<MclkDefined, SMCLK, XT1CLK> {
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Dcoclk(target_freq)), self.smclk, self.xt1clk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Dcoclk(target_freq)), self.smclk, self.xt1clk, self.fll_ref)
         }
     }
 
     /// Enable SMCLK and set SMCLK divider, which divides the MCLK frequency
     #[inline]
     pub fn smclk_on(self, div: SmclkDiv) -> ClockConfig<MCLK, SmclkDefined, XT1CLK> {
-        make_clkconf!(self, self.mclk, SmclkDefined(div), self.xt1clk)
+        make_clkconf!(self, self.mclk, SmclkDefined(div), self.xt1clk, self.fll_ref)
     }
 
     /// Disable SMCLK
     #[inline]
     pub fn smclk_off(self) -> ClockConfig<MCLK, SmclkDisabled, XT1CLK> {
-        make_clkconf!(self, self.mclk, SmclkDisabled, self.xt1clk)
+        make_clkconf!(self, self.mclk, SmclkDisabled, self.xt1clk, self.fll_ref)
     }
 
     /// Enable XT1 with specific hardware requirements
@@ -489,15 +491,13 @@ impl<MCLK, SMCLK, XT1CLK> ClockConfig<MCLK, SMCLK, XT1CLK> {
         self, 
         config: Xt1Config<MODE>
     ) -> ClockConfig<MCLK, SMCLK, Xt1Defined<MODE>> {
-        // Here you would write to the CSCTL registers 
-        // using the values inside `config`
-        make_clkconf!(self, self.mclk, self.smclk, Xt1Defined(config))
+        make_clkconf!(self, self.mclk, self.smclk, Xt1Defined(config), self.fll_ref)
     }
 
     /// Explicitly disable XT1 to save power
     #[inline]
     pub fn xt1clk_off(self) -> ClockConfig<MCLK, SMCLK, Xt1Disabled> {
-        make_clkconf!(self, self.mclk, self.smclk, Xt1Disabled)
+        make_clkconf!(self, self.mclk, self.smclk, Xt1Disabled, Selref::Refoclk)
     }
 }
 
@@ -515,10 +515,10 @@ impl<MCLK, SMCLK, MODE> ClockConfig<MCLK, SMCLK, Xt1Defined<MODE>> {
         self,
         mclk_div: MclkDiv,
     ) -> ClockConfig<MclkDefined, SMCLK, Xt1Defined<MODE>> {
-        let freq = self.xt1clk.0.frequency;
+        let freq = self.xt1clk.freq();
         ClockConfig {
             mclk_div,
-            ..make_clkconf!(self, MclkDefined(MclkSel::Xt1clk(freq)), self.smclk, self.xt1clk)
+            ..make_clkconf!(self, MclkDefined(MclkSel::Xt1clk(freq)), self.smclk, self.xt1clk, self.fll_ref)
         }
     }
 

--- a/hal/src/device_specific/fr2433.rs
+++ b/hal/src/device_specific/fr2433.rs
@@ -453,3 +453,10 @@ mod timer {
     }
     impl CapCmpTimer3 for Timer1A3 {}
 }
+
+pub mod clock {
+    use crate::{gpio::*, clock::*};
+
+    impl<DIR> Xt1XinPin  for Pin<P2, Pin1, Alternate1<DIR>> {}
+    impl<DIR> Xt1XoutPin for Pin<P2, Pin0, Alternate1<DIR>> {}
+}

--- a/hal/src/device_specific/fr247x.rs
+++ b/hal/src/device_specific/fr247x.rs
@@ -18,11 +18,11 @@ pub mod gpio {
     impl<PULL> ToAlternate2 for Pin<P1, Pin0, Input<PULL>> {}
     impl<DIR>  ToAlternate2 for Pin<P1, Pin1, DIR> {}
     impl<DIR>  ToAlternate2 for Pin<P1, Pin2, DIR> {}
-    impl ToAlternate2 for Pin<P1, Pin3, Output> {}
+    impl ToAlternate2       for Pin<P1, Pin3, Output> {}
     impl<DIR>  ToAlternate2 for Pin<P1, Pin4, DIR> {}
     impl<DIR>  ToAlternate2 for Pin<P1, Pin5, DIR> {}
     impl<PULL> ToAlternate2 for Pin<P1, Pin6, Input<PULL>> {}
-    impl ToAlternate2 for Pin<P1, Pin7, Output> {}
+    impl ToAlternate2       for Pin<P1, Pin7, Output> {}
     // P1 alternate 3
     impl<PIN: PinNum, DIR> ToAlternate3 for Pin<P1, PIN, DIR> {}
 
@@ -49,7 +49,7 @@ pub mod gpio {
     impl<DIR>  ToAlternate1 for Pin<P3, Pin6, DIR> {}
     impl<DIR>  ToAlternate1 for Pin<P3, Pin7, DIR> {}
     // P3 alternate 2
-    impl ToAlternate2 for Pin<P3, Pin4, Output> {}
+    impl ToAlternate2       for Pin<P3, Pin4, Output> {}
     impl<PULL> ToAlternate2 for Pin<P3, Pin5, Input<PULL>> {}
 
 
@@ -1051,4 +1051,11 @@ mod timer {
         type Tbxclk = Pin<P2, Pin7, Alternate1<Input<Floating>>>;
     }
     impl CapCmpTimer7 for Tb0 {}
+}
+
+pub mod clock {
+    use crate::{gpio::*, clock::*};
+
+    impl<DIR> Xt1XinPin  for Pin<P2, Pin1, Alternate1<DIR>> {}
+    impl<DIR> Xt1XoutPin for Pin<P2, Pin0, Alternate1<DIR>> {}
 }

--- a/hal/src/device_specific/fr2x5x.rs
+++ b/hal/src/device_specific/fr2x5x.rs
@@ -783,3 +783,10 @@ mod timer {
     }
     impl CapCmpTimer7 for Tb3 {}
 }
+
+pub mod clock {
+    use crate::{gpio::*, clock::*};
+
+    impl<DIR> Xt1XinPin  for Pin<P2, Pin7, Alternate1<DIR>> {}
+    impl<DIR> Xt1XoutPin for Pin<P2, Pin6, Alternate1<DIR>> {}
+}

--- a/hal/src/pwm.rs
+++ b/hal/src/pwm.rs
@@ -8,7 +8,7 @@
 
 use crate::gpio::ChangeSelectBits;
 use crate::hw_traits::timer_base::{CCRn, Outmod};
-use crate::pin_mapping::PinMap;
+use crate::pin_mapping::{DefaultMapping, PinMap};
 use crate::timer::{CapCmpTimer3, CapCmpTimer7};
 use core::marker::PhantomData;
 
@@ -49,7 +49,7 @@ pub trait PwmPeriph<C>: CapCmp<C> + CapCmp<CCR0> {
 }
 
 
-fn setup_pwm<T: TimerPeriph<M>, M: PinMap = DefaultMapping>(timer: &T, config: TimerConfig<T, M>, period: u16) {
+fn setup_pwm<T: TimerPeriph<M>, M: PinMap>(timer: &T, config: TimerConfig<T, M>, period: u16) {
     config.write_regs(timer);
     CCRn::<CCR0>::set_ccrn(timer, period);
     CCRn::<CCR0>::config_outmod(timer, Outmod::Toggle);
@@ -64,7 +64,7 @@ pub struct PwmParts3<T: CapCmpTimer3<M>, M: PinMap = DefaultMapping> {
     _pin_map: PhantomData<M>,
 }
 
-impl<T: CapCmpTimer3<M>, M: PinMap = DefaultMapping> PwmParts3<T, M> {
+impl<T: CapCmpTimer3<M>, M: PinMap> PwmParts3<T, M> {
     /// Create uninitialized PWM pins with the same period
     pub fn new(timer: T, config: TimerConfig<T, M>, period: u16) -> Self {
         setup_pwm(&timer, config, period);
@@ -98,7 +98,7 @@ pub struct PwmParts7<T: CapCmpTimer7<M>, M: PinMap = DefaultMapping> {
     _pin_map: PhantomData<M>,
 }
 
-impl<T: CapCmpTimer7<M>, M: PinMap = DefaultMapping> PwmParts7<T, M> {
+impl<T: CapCmpTimer7<M>, M: PinMap> PwmParts7<T, M> {
     /// Create uninitialized PWM pins with the same period
     pub fn new(timer: T, config: TimerConfig<T, M>, period: u16) -> Self {
         setup_pwm(&timer, config, period);

--- a/hal/src/pwm.rs
+++ b/hal/src/pwm.rs
@@ -49,14 +49,14 @@ pub trait PwmPeriph<C>: CapCmp<C> + CapCmp<CCR0> {
 }
 
 
-fn setup_pwm<T: TimerPeriph<M>, M: PinMap>(timer: &T, config: TimerConfig<T, M>, period: u16) {
+fn setup_pwm<T: TimerPeriph<M>, M: PinMap = DefaultMapping>(timer: &T, config: TimerConfig<T, M>, period: u16) {
     config.write_regs(timer);
     CCRn::<CCR0>::set_ccrn(timer, period);
     CCRn::<CCR0>::config_outmod(timer, Outmod::Toggle);
 }
 
 /// Collection of uninitialized PWM pins derived from timer peripheral with 3 capture-compare registers
-pub struct PwmParts3<T: CapCmpTimer3<M>, M: PinMap> {
+pub struct PwmParts3<T: CapCmpTimer3<M>, M: PinMap = DefaultMapping> {
     /// PWM pin 1 (derived from capture-compare register 1)
     pub pwm1: PwmUninit<T, CCR1>,
     /// PWM pin 2 (derived from capture-compare register 2)
@@ -64,7 +64,7 @@ pub struct PwmParts3<T: CapCmpTimer3<M>, M: PinMap> {
     _pin_map: PhantomData<M>,
 }
 
-impl<T: CapCmpTimer3<M>, M: PinMap> PwmParts3<T, M> {
+impl<T: CapCmpTimer3<M>, M: PinMap = DefaultMapping> PwmParts3<T, M> {
     /// Create uninitialized PWM pins with the same period
     pub fn new(timer: T, config: TimerConfig<T, M>, period: u16) -> Self {
         setup_pwm(&timer, config, period);
@@ -82,7 +82,7 @@ impl<T: CapCmpTimer3<M>, M: PinMap> PwmParts3<T, M> {
 }
 
 /// Collection of uninitialized PWM pins derived from timer peripheral with 7 capture-compare registers
-pub struct PwmParts7<T: CapCmpTimer7<M>, M: PinMap> {
+pub struct PwmParts7<T: CapCmpTimer7<M>, M: PinMap = DefaultMapping> {
     /// PWM pin 1 (derived from capture-compare register 1)
     pub pwm1: PwmUninit<T, CCR1>,
     /// PWM pin 2 (derived from capture-compare register 2)
@@ -98,7 +98,7 @@ pub struct PwmParts7<T: CapCmpTimer7<M>, M: PinMap> {
     _pin_map: PhantomData<M>,
 }
 
-impl<T: CapCmpTimer7<M>, M: PinMap> PwmParts7<T, M> {
+impl<T: CapCmpTimer7<M>, M: PinMap = DefaultMapping> PwmParts7<T, M> {
     /// Create uninitialized PWM pins with the same period
     pub fn new(timer: T, config: TimerConfig<T, M>, period: u16) -> Self {
         setup_pwm(&timer, config, period);

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -2,11 +2,17 @@
 //!
 //! Can be used as a periodic 16-bit timer.
 //! 
-//! Supports using SMCLK or VLOCLK as clock sources (ACLK and XT1CLK not yet supported).
+//! Supports SMCLK, ACLK, VLOCLK, and XT1CLK as clock sources.
+//! 
+//! Note: On FR2x5x and FR247x series, ACLK and SMCLK share the same RTCCKSEL 
+//! hardware bit pattern and are further distinguished via SYSCFG2 selection.
 
-use crate::clock::Smclk;
+use crate::clock::{Smclk, Xt1clk};
 use core::{convert::Infallible, marker::PhantomData};
 use crate::_pac::{self, rtc::rtcctl::Rtcss};
+
+#[cfg(feature = "rtc_aclk")]
+use crate::clock::Aclk;
 
 mod sealed {
     use super::*;
@@ -15,12 +21,19 @@ mod sealed {
 
     impl SealedRtcClockSrc for RtcSmclk {}
     impl SealedRtcClockSrc for RtcVloclk {}
+    #[cfg(feature = "rtc_aclk")]
+    impl SealedRtcClockSrc for RtcAclk {}
+    impl SealedRtcClockSrc for RtcXt1clk {}
 }
 
 /// Marker trait for RTC clock sources
 pub trait RtcClockSrc: sealed::SealedRtcClockSrc {
     #[doc(hidden)]
     const CLK_SRC: Rtcss;
+
+    /// Optional hook for clock-specific hardware configuration (e.g., SYSCFG muxes)
+    #[doc(hidden)]
+    fn apply_sys_config() {}
 }
 
 /// Typestate representing the SMCLK clock source for RTC
@@ -28,6 +41,13 @@ pub struct RtcSmclk;
 
 impl RtcClockSrc for RtcSmclk {
     const CLK_SRC: Rtcss = Rtcss::Smclk;
+    
+    #[cfg(feature = "rtc_aclk")]
+    fn apply_sys_config() {
+        // Ensure the mux is set to SMCLK (0)
+        let sys = unsafe { &*_pac::Sys::ptr() };
+        sys.syscfg2().modify(|_, w| w.rtccksel().clear_bit());
+    }
 }
 
 /// Typestate representing the VLOCLK clock source for RTC
@@ -35,6 +55,28 @@ pub struct RtcVloclk;
 
 impl RtcClockSrc for RtcVloclk {
     const CLK_SRC: Rtcss = Rtcss::Vloclk;
+}
+
+/// Typestate representing the ACLK clock source for RTC
+#[cfg(feature = "rtc_aclk")]
+pub struct RtcAclk;
+
+#[cfg(feature = "rtc_aclk")]
+impl RtcClockSrc for RtcAclk {
+    const CLK_SRC: Rtcss = Rtcss::Smclk;
+    
+    fn apply_sys_config() {
+        // Ensure the mux is set to SMCLK (0)
+        let sys = unsafe { &*_pac::Sys::ptr() };
+        sys.syscfg2().modify(|_, w| w.rtccksel().set_bit());
+    }
+}
+
+/// Typestate representing the XT1CLK clock source for RTC
+pub struct RtcXt1clk;
+
+impl RtcClockSrc for RtcXt1clk {
+    const CLK_SRC: Rtcss = Rtcss::Xt1clk;
 }
 
 /// 16-bit real-time counter
@@ -66,10 +108,31 @@ impl<SRC: RtcClockSrc> Rtc<SRC> {
         }
     }
 
+    /// Configure the RTC to use ACLK as clock source. Setting comes in effect the next time RTC
+    /// is started.
+    #[inline]
+    #[cfg(feature = "rtc_aclk")]
+    pub fn use_aclk(self, _aclk: &Aclk) -> Rtc<RtcAclk> {
+        Rtc {
+            periph: self.periph,
+            _src: PhantomData,
+        }
+    }
+
     /// Configure the RTC to use VLOCLK as clock source. Setting comes in effect the next time RTC
     /// is started.
     #[inline]
     pub fn use_vloclk(self) -> Rtc<RtcVloclk> {
+        Rtc {
+            periph: self.periph,
+            _src: PhantomData,
+        }
+    }
+
+    /// Configure the RTC to use XT1CLK as clock source. Setting comes in effect the next time RTC
+    /// is started.
+    #[inline]
+    pub fn use_xt1clk(self, _xt1clk: &Xt1clk) -> Rtc<RtcXt1clk> {
         Rtc {
             periph: self.periph,
             _src: PhantomData,
@@ -116,6 +179,7 @@ impl<SRC: RtcClockSrc> Rtc<SRC> {
             .write(|w| unsafe { w.bits(count) });
         // Need to clear interrupt flag from last timer run
         self.periph.rtciv().read();
+        SRC::apply_sys_config();
         self.periph.rtcctl().modify(|r, w| {
             unsafe { w.bits(r.bits()) }
                 .rtcss()


### PR DESCRIPTION
This PR adds support for the XT1 external crystal oscillator, providing both Crystal and Bypass modes through the updated ClockConfig builder. Additionally, this update resolves an issue with missing PWM default mappings and added aclk and xt1clk as RTC sources.