### PR TITLE
feat: add support to msp430fr25x2 devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         rust_toolchain: [nightly, nightly-2024-09-01]
-        device: [msp430fr2355, msp430fr2476, msp430fr2433, msp430fr2512, msp430fr2522]
+        device: [msp430fr2355, msp430fr2476, msp430fr2433, msp430fr2522]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       - name: Build library
         working-directory: hal/
         run: cargo +${{matrix.rust_toolchain}} build --features ${{matrix.device}}
-    
+
       - name: Build library with ehal02
         working-directory: hal/
         run: cargo +${{matrix.rust_toolchain}} build --features ${{matrix.device}},embedded-hal-02
@@ -48,7 +48,7 @@ jobs:
         if: matrix.rust_toolchain == 'nightly'
         working-directory: device-examples/${{matrix.device}}
         run: cargo build --examples
-      
+
       - name: Build MSRV examples
         if: matrix.rust_toolchain != 'nightly'
         working-directory: device-examples/${{matrix.device}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         rust_toolchain: [nightly, nightly-2024-09-01]
-        device: [msp430fr2355, msp430fr2476, msp430fr2433]
+        device: [msp430fr2355, msp430fr2476, msp430fr2433, msp430fr2512, msp430fr2522]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An example can be flashed to a connected device with
 `cargo run --example <example_name>`
 
 # Supported Devices
-The library currently supports the MSP430FR2x5x and MSP430FR247x subfamilies, and the MSP430FR2433.
+The library currently supports the MSP430FR2x5x and MSP430FR247x and MSP430FR25x2 subfamilies, and the MSP430FR2433.
 Support for other devices in the MSP430FR2xxx/4xxx family is possible, see [Supporting additional devices](##Supporting-additional-devices). 
 
 The device being targetted is must be specified by enabling exactly one device feature, such as 
@@ -45,6 +45,8 @@ The device being targetted is must be specified by enabling exactly one device f
 | MSP430FR2353 | `msp430fr2353` |
 | MSP430FR2155 | `msp430fr2155` |
 | MSP430FR2153 | `msp430fr2153` |
+| MSP430FR2512 | `msp430fr2512` |
+| MSP430FR2522 | `msp430fr2522` |
 
 The documentation on crates.rs (and example programs) target the MSP430FR2355. Documentation for a particular device can be 
 built by running `cargo doc --open --features <device>` from within the `hal/` folder, or `cargo doc --open --package msp430fr2x5x-hal` in a 

--- a/device-examples/msp430fr2522/.cargo/config.toml
+++ b/device-examples/msp430fr2522/.cargo/config.toml
@@ -1,0 +1,32 @@
+[target.msp430-none-elf]
+# For debugging
+# runner = "msp430-elf-gdb -q -x mspdebug.gdb"
+# For running
+runner = "./run.sh"
+
+rustflags = [
+    "-C",
+    "link-arg=-nostartfiles",
+    "-C",
+    "link-arg=-Tlink.x",
+    "-C",
+    "link-arg=-mcpu=msp430",
+
+    # Even though this chip has a HW multiplier, enabling it causes link errors, so we'll link the software multiplier for now
+    "-C",
+    "link-arg=-lmul_none",
+    #"-C", "link-arg=-lmul_32",
+    #"-C", "link-arg=-Wl,--allow-multiple-definition", # Prevent __muldi3 dupe errors
+
+    # libgcc must be linked after everything that depends on it (e.g. lmul_none)
+    "-C",
+    "link-arg=-lgcc",
+]
+
+[build]
+target = "msp430-none-elf"
+
+[unstable]
+# MSP430 doesn't come with libcore compiled already. But when it does, this
+# key can be removed.
+build-std = ["core"]

--- a/device-examples/msp430fr2522/Cargo.toml
+++ b/device-examples/msp430fr2522/Cargo.toml
@@ -12,7 +12,7 @@ panic-msp430 = "0.4.0"
 panic-never = "0.1.0"
 msp430 = { version = "0.4.1", features = ["critical-section-single-core"] }
 msp430-rt = "0.4.0"
-msp430fr25x2 = { version = "0.3.1", features = ["rt", "critical-section"]}
+msp430fr25x2 = { version = "0.3.2", features = ["rt", "critical-section"]}
 msp430fr2x5x-hal = { path = "../../hal", features = ["msp430fr2522"] }
 critical-section = "1.2.0"
 msp430-atomic = "0.1.5"

--- a/device-examples/msp430fr2522/Cargo.toml
+++ b/device-examples/msp430fr2522/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "msp430fr25x2-hal-examples"
+version = "0.0.1"
+authors = ["Ross Porter <rossporter506@gmail.com>"]
+edition = "2021"
+description = "MSP430FR25x2 examples using the msp430fr2x5x-hal"
+publish = false
+keywords = ["no-std", "msp430", "ti", "launchpad", "embedded-hal"]
+
+[dependencies]
+panic-msp430 = "0.4.0"
+panic-never = "0.1.0"
+msp430 = { version = "0.4.1", features = ["critical-section-single-core"] }
+msp430-rt = "0.4.0"
+msp430fr25x2 = { version = "0.3.1", features = ["rt", "critical-section"]}
+msp430fr2x5x-hal = { path = "../../hal", features = ["msp430fr2522"] }
+critical-section = "1.2.0"
+msp430-atomic = "0.1.5"
+embedded-hal = "1.0"
+embedded-hal-nb = "*"
+embedded-io = "0.7"
+nb = "1.1.0"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = "z"
+
+[profile.dev]
+opt-level = "s"
+codegen-units = 1
+debug = true
+
+[profile.dev.package."*"]
+opt-level = "z"
+
+# Mark which examples don't work on the MSRV compiler, so CI doesn't build them when using the MSRV.
+# By default all examples are enabled, building with MSRV requires passing `--no-default-features`.
+[features]
+default = ["non_msrv"]
+non_msrv = []
+
+# Examples that don't work on the MSRV compiler
+[[example]]
+name = "lpm0"
+required-features = ["non_msrv"]

--- a/device-examples/msp430fr2522/Cargo.toml
+++ b/device-examples/msp430fr2522/Cargo.toml
@@ -27,6 +27,7 @@ codegen-units = 1
 opt-level = "z"
 
 [profile.dev]
+lto = "fat"
 opt-level = "s"
 codegen-units = 1
 debug = true

--- a/device-examples/msp430fr2522/debug.sh
+++ b/device-examples/msp430fr2522/debug.sh
@@ -1,0 +1,1 @@
+mspdebug --allow-fw-update tilib -C <(echo "gdb")

--- a/device-examples/msp430fr2522/examples/adc.rs
+++ b/device-examples/msp430fr2522/examples/adc.rs
@@ -1,0 +1,60 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    adc::{AdcConfig, ClockDivider, Predivider, Resolution, SampleTime, SamplingRate},
+    gpio::Batch,
+    pmm::Pmm,
+    watchdog::Wdt,
+};
+use nb::block;
+use panic_msp430 as _;
+
+// If pin 1.1 is between 1V and 2V, the LED on pin 1.0 should light up.
+#[entry]
+fn main() -> ! {
+    // Take peripherals and disable watchdog
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    // Configure GPIO
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let port1 = Batch::new(periph.p1).split(&pmm);
+    let mut led = port1.pin0.to_output();
+    let mut adc_pin = port1.pin1.to_alternate3();
+
+    // ADC setup
+    let mut adc = AdcConfig::new(
+        ClockDivider::_1,
+        Predivider::_1,
+        Resolution::_8BIT,
+        SamplingRate::_50KSPS,
+        SampleTime::_4,
+    )
+    .use_modclk()
+    .configure(periph.adc);
+
+    loop {
+        // Get ADC voltage, assuming the ADC reference voltage is 3300mV
+        // It's infallible besides nb::WouldBlock, so it's safe to unwrap after block!()
+        // If you want a raw count use adc.read_count() instead.
+        let reading_mv = block!(adc.read_voltage_mv(&mut adc_pin, 3300)).unwrap();
+
+        // Turn on LED if voltage between 1000 and 2000mV
+        if (1000..=2000).contains(&reading_mv) {
+            led.set_high().ok();
+        } else {
+            led.set_low().ok();
+        }
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/adc_temp_sensor.rs
+++ b/device-examples/msp430fr2522/examples/adc_temp_sensor.rs
@@ -1,0 +1,69 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    adc::{AdcConfig, ClockDivider, Predivider, Resolution, SampleTime, SamplingRate},
+    gpio::Batch,
+    pmm::{Pmm, ReferenceVoltage},
+    watchdog::Wdt,
+};
+use nb::block;
+use panic_msp430 as _;
+
+// Turn on P1.0 if temp between 20 and 25C
+#[entry]
+fn main() -> ! {
+    // Take peripherals and disable watchdog
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    // Configure GPIO
+    let (mut pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let port1 = Batch::new(periph.p1).split(&pmm);
+    let mut led = port1.pin0.to_output();
+
+    // ADC setup.
+    // Temp sensor needs >= 30 us sample time.
+    // MODCLK is < ~4.6MHz, so 256 cycles / 4.6 MHz = 55 us sample time.
+    let mut adc = AdcConfig::new(
+        ClockDivider::_1,
+        Predivider::_1,
+        Resolution::_12BIT,
+        SamplingRate::_200KSPS,
+        SampleTime::_256,
+    )
+    .use_modclk()
+    .configure(periph.adc);
+
+    let vref = pmm
+        .enable_internal_reference(ReferenceVoltage::_1V5)
+        .unwrap();
+    let mut t_sense = pmm.enable_internal_temp_sensor(&vref).unwrap();
+
+    loop {
+        // Get the voltage of the internal temp sensor, assuming the ADC reference voltage is 3300mV
+        let reading_mv = block!(adc.read_voltage_mv(&mut t_sense, 3300)).unwrap();
+
+        // Equation 11 gives us this equation for calculating temperature from the temp sensor voltage:
+        // T = 0.00355 × (V_t – V_30C) + 30C, and V_30C = 788 mV (8.12.5.1).
+        // Note integer division, so multiply first (beware overflow!), divide last to maximise accuracy
+        let temp_celcius = (((355 * (reading_mv as i32 - 788)) + 30_000) / 1000) as i16;
+
+        // Turn on LED if temp between 20 and 25C
+        if (20..=25).contains(&temp_celcius) {
+            led.set_high().ok();
+        } else {
+            led.set_low().ok();
+        }
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/alternate.rs
+++ b/device-examples/msp430fr2522/examples/alternate.rs
@@ -1,0 +1,33 @@
+#![no_main]
+#![no_std]
+
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{gpio::Batch, pmm::Pmm, watchdog::Wdt};
+use panic_msp430 as _;
+
+// Alternate GPIO mode demonstration
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+
+    // Convert P1.7 to SMCLK output
+    // Expect red LED to light up
+    p1.pin7.to_output().to_alternate1();
+
+    loop {
+        msp430::asm::nop();
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/backup_memory.rs
+++ b/device-examples/msp430fr2522/examples/backup_memory.rs
@@ -1,0 +1,44 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{bak_mem::BackupMemory, gpio::Batch, pmm::Pmm};
+use panic_msp430 as _;
+
+// Use the value of backup memory to toggle the red onboard LED. The red LED should flash.
+// Backup memory maintains it's value through a system reset. Power loss *will* reset the backup memory, however.
+
+#[entry]
+fn main() -> ! {
+    // Take peripherals
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    // DON'T disable the watchdog. It will reset us after a few ms.
+    //let _wdt = Wdt::constrain(periph.wdt_a);
+
+    // Configure GPIO
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let mut led = Batch::new(periph.p1).split(&pmm).pin0.to_output();
+
+    // Interpret register block as a &mut [u8;32]
+    let bk_mem = BackupMemory::as_u8s(periph.bkmem);
+
+    bk_mem[0] = bk_mem[0].wrapping_add(1);
+
+    // Set the output pin high if nv_mem is a multiple of 10
+    led.set_state((bk_mem[0] % 10 == 0).into()).ok();
+
+    // Loop until the watchdog resets us
+    loop {
+        msp430::asm::nop();
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/blinky.rs
+++ b/device-examples/msp430fr2522/examples/blinky.rs
@@ -1,0 +1,48 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::{delay::DelayNs, digital::*};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pmm::Pmm,
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+// Red onboard LED should blink at a steady period.
+#[entry]
+fn main() -> ! {
+    // Take peripherals and disable watchdog
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    // Configure GPIO
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let port1 = Batch::new(periph.p1).split(&pmm);
+    let mut p1_0 = port1.pin0.to_output();
+
+    // Configure clocks to get accurate delay timing
+    let mut fram = Fram::new(periph.frctl);
+    let (_smclk, _aclk, mut delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .freeze(&mut fram);
+
+    loop {
+        // `toggle()` returns a `Result` because of embedded_hal, but the result is always `Ok` with MSP430 GPIO.
+        // Rust complains about unused Results, so we 'use' the Result by calling .ok()
+        p1_0.toggle().ok();
+        delay.delay_ms(500);
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/capture.rs
+++ b/device-examples/msp430fr2522/examples/capture.rs
@@ -1,0 +1,119 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use embedded_hal_nb::serial::Write;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    capture::{CapTrigger, CaptureParts3, OverCapture, TimerConfig},
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pmm::Pmm,
+    prelude::*,
+    serial::*,
+    watchdog::Wdt,
+};
+use nb::block;
+use panic_msp430 as _;
+
+// Connect push button input to P1.1. When button is pressed, putty should print the # of cycles
+// since the last press. Sometimes we get 2 consecutive readings due to lack of debouncing.
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let mut p1 = Batch::new(periph.p1)
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+
+    let (smclk, aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let mut tx = SerialConfig::new(
+        periph.e_usci_a0,
+        BitOrder::LsbFirst,
+        BitCount::EightBits,
+        StopBits::OneStopBit,
+        Parity::NoParity,
+        Loopback::NoLoop,
+        9600,
+    )
+    .use_smclk(&smclk)
+    .tx_only(p1.pin4.to_alternate1());
+
+    let captures = CaptureParts3::config(periph.ta0, TimerConfig::aclk(&aclk))
+        .config_cap2_input_A(p1.pin5.to_alternate2())
+        .config_cap1_trigger(CapTrigger::FallingEdge)
+        .commit();
+    let mut capture = captures.cap1;
+
+    let mut last_cap = 0;
+    loop {
+        match block!(capture.capture()) {
+            Ok(cap) => {
+                let diff = cap.wrapping_sub(last_cap);
+                last_cap = cap;
+                p1.pin0.set_high().unwrap();
+                print_num(&mut tx, diff);
+            }
+            Err(OverCapture(_)) => {
+                p1.pin0.set_high().unwrap();
+                write(&mut tx, '!');
+                write(&mut tx, '\n');
+            }
+        }
+    }
+}
+
+fn print_num<U: SerialUsci>(tx: &mut Tx<U>, num: u16) {
+    write(tx, '0');
+    write(tx, 'x');
+    print_hex(tx, num >> 12);
+    print_hex(tx, (num >> 8) & 0xF);
+    print_hex(tx, (num >> 4) & 0xF);
+    print_hex(tx, num & 0xF);
+    write(tx, '\n');
+}
+
+fn print_hex<U: SerialUsci>(tx: &mut Tx<U>, h: u16) {
+    let c = match h {
+        0 => '0',
+        1 => '1',
+        2 => '2',
+        3 => '3',
+        4 => '4',
+        5 => '5',
+        6 => '6',
+        7 => '7',
+        8 => '8',
+        9 => '9',
+        10 => 'a',
+        11 => 'b',
+        12 => 'c',
+        13 => 'd',
+        14 => 'e',
+        15 => 'f',
+        _ => '?',
+    };
+    write(tx, c);
+}
+
+fn write<U: SerialUsci>(tx: &mut Tx<U>, ch: char) {
+    nb::block!(tx.write(ch as u8)).unwrap();
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/capture_intr.rs
+++ b/device-examples/msp430fr2522/examples/capture_intr.rs
@@ -1,0 +1,111 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+
+// This example also demonstrates how to write panic-free code using panic_never.
+
+use core::cell::UnsafeCell;
+use critical_section::with;
+use embedded_hal::digital::StatefulOutputPin;
+use msp430::interrupt::{enable, Mutex};
+use msp430_rt::entry;
+use msp430fr25x2::interrupt;
+use msp430fr2x5x_hal::{
+    capture::{
+        CapCmp, CapTrigger, Capture, CaptureParts3, CaptureVector, TBxIV, TimerConfig, CCR2,
+    },
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::{Batch, *},
+    pin_mapping::*,
+    pmm::Pmm,
+    watchdog::Wdt,
+};
+
+#[cfg(debug_assertions)]
+use panic_msp430 as _;
+
+#[cfg(not(debug_assertions))]
+use panic_never as _;
+
+// We use UnsafeCell as a panic-free version of RefCell. If you aren't using `panic_never` then RefCell is more ergonomic.
+static CAPTURE: Mutex<UnsafeCell<Option<Capture<msp430fr25x2::Ta0, CCR2>>>> =
+    Mutex::new(UnsafeCell::new(None));
+static VECTOR: Mutex<UnsafeCell<Option<TBxIV<msp430fr25x2::Ta0, DefaultMapping>>>> =
+    Mutex::new(UnsafeCell::new(None));
+static RED_LED: Mutex<UnsafeCell<Option<Pin<P1, Pin0, Output>>>> =
+    Mutex::new(UnsafeCell::new(None));
+
+// Connect push button input to P1.6. When button is pressed, red LED should toggle. No debouncing,
+// so sometimes inputs are missed.
+#[entry]
+fn main() -> ! {
+    let Some(periph) = msp430fr25x2::Peripherals::take() else {
+        loop {}
+    };
+    let mut fram = Fram::new(periph.frctl);
+    Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1)
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+    let red_led = p1.pin0;
+
+    with(|cs| unsafe { *RED_LED.borrow(cs).get() = Some(red_led) });
+
+    let (_smclk, aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let captures = CaptureParts3::config(periph.ta0, TimerConfig::aclk(&aclk))
+        .config_cap2_input_A(p1.pin5.to_alternate2())
+        .config_cap2_trigger(CapTrigger::FallingEdge)
+        .commit();
+    let mut capture = captures.cap2;
+    let vectors = captures.tbxiv;
+
+    setup_capture(&mut capture);
+    with(|cs| {
+        unsafe { *CAPTURE.borrow(cs).get() = Some(capture) }
+        unsafe { *VECTOR.borrow(cs).get() = Some(vectors) }
+    });
+    unsafe { enable() };
+
+    loop {}
+}
+
+fn setup_capture<T: CapCmp<C>, C>(capture: &mut Capture<T, C>) {
+    capture.enable_interrupts();
+}
+
+#[interrupt]
+fn TIMER0_A1() {
+    with(|cs| {
+        let Some(vector) = unsafe { &mut *VECTOR.borrow(cs).get() }.as_mut() else {
+            return;
+        };
+        let Some(capture) = unsafe { &mut *CAPTURE.borrow(cs).get() }.as_mut() else {
+            return;
+        };
+        let Some(led) = unsafe { &mut *RED_LED.borrow(cs).get() }.as_mut() else {
+            return;
+        };
+
+        if let CaptureVector::Capture2(cap) = vector.interrupt_vector() {
+            if cap.interrupt_capture(capture).is_ok() {
+                led.toggle().unwrap();
+            }
+        };
+    });
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/clocks.rs
+++ b/device-examples/msp430fr2522/examples/clocks.rs
@@ -1,0 +1,60 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pmm::Pmm,
+    watchdog::{Wdt, WdtClkPeriods},
+};
+use nb::block;
+use panic_msp430 as _;
+
+// Red LED should blink 1 second on, 1 second off
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    let wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1)
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+    let mut p1_0 = p1.pin0;
+
+    let (smclk, _aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    const DELAY: WdtClkPeriods = WdtClkPeriods::_8192k;
+
+    // blinks should be 1 second on, 1 second off
+    let mut wdt = wdt.to_interval();
+    p1_0.set_high().ok();
+    wdt.set_smclk(&smclk).set_interval_and_start(DELAY);
+
+    block!(wdt.wait()).ok();
+    p1_0.set_low().ok();
+
+    let mut wdt = wdt.to_watchdog();
+    wdt.set_interval_and_start(DELAY);
+
+    loop {
+        msp430::asm::nop();
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/crc.rs
+++ b/device-examples/msp430fr2522/examples/crc.rs
@@ -1,0 +1,71 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::OutputPin;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{crc::Crc, gpio::Batch, pmm::Pmm, watchdog::Wdt};
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+    let mut led = p1.pin0.to_output();
+
+    // Some random data to create a signature over. Can be modified.
+    let crc_input = [
+        0x0fc0, 0x1096, 0x5042, 0x0010, 0x7ff7, 0xf86a, 0xb58e, 0x7651, 0x8b88, 0x0679, 0x0123,
+        0x9599, 0xc58c, 0xd1e2, 0xe144, 0xb691,
+    ];
+
+    // Configure the hardware CRC module, pass in the data and retrieve the signature.
+    let mut crc_hw = Crc::new(periph.crc, 0xFFFF);
+    crc_hw.add_words_lsb(&crc_input);
+    let hw_sig = crc_hw.result();
+
+    // Calculate the same CRC using a software implementation
+    let sw_sig = calculate_software_sig(0xFFFF, &crc_input);
+
+    // Turn on the LED if the signatures match
+    led.set_state((sw_sig == hw_sig).into()).ok();
+
+    loop {
+        msp430::asm::nop();
+    }
+}
+
+fn calculate_software_sig(seed: u16, data: &[u16]) -> u16 {
+    let mut sig: u16 = seed;
+
+    for val in data {
+        let low_byte = (val & 0xFF) as u8;
+        let high_byte = (val >> 8) as u8;
+        ccitt_update(&mut sig, low_byte);
+        ccitt_update(&mut sig, high_byte);
+    }
+
+    sig
+}
+
+// Software algorithm - CCITT CRC16 code. Derived from msp430fr235x_CRC.c, at:
+// https://dev.ti.com/tirex/explore/node?node=A__AIgIaFR0j9SeqBvdp6wD2w__msp430ware__IOGqZri__LATEST
+fn ccitt_update(sig: &mut u16, input: u8) {
+    let mut new = *sig;
+    new = new.rotate_right(8);
+    new ^= input as u16;
+    new ^= (new & 0xFF) >> 4;
+    new ^= new << 12;
+    new ^= (new & 0xFF) << 5;
+    *sig = new;
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/echo.rs
+++ b/device-examples/msp430fr2522/examples/echo.rs
@@ -1,0 +1,82 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::OutputPin;
+use embedded_hal_nb::serial::{Read, Write};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pin_mapping::DefaultMapping,
+    pmm::Pmm,
+    serial::*,
+    watchdog::Wdt,
+};
+
+use nb::block;
+#[cfg(debug_assertions)]
+use panic_msp430 as _;
+
+#[cfg(not(debug_assertions))]
+use panic_never as _;
+
+// Prints "HELLO" when started then echos on UART1
+// Serial settings are listed in the code
+#[entry]
+fn main() -> ! {
+    if let Some(periph) = msp430fr25x2::Peripherals::take() {
+        let mut fram = Fram::new(periph.frctl);
+        let _wdt = Wdt::constrain(periph.wdt_a);
+
+        let (_smclk, aclk, _delay) = ClockConfig::new(periph.cs)
+            .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+            .smclk_on(SmclkDiv::_2)
+            .aclk_refoclk()
+            .freeze(&mut fram);
+
+        let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+        let p1 = Batch::new(periph.p1).split(&pmm);
+
+        let mut led = p1.pin0.to_output();
+
+        led.set_low().ok();
+
+        let (mut tx, mut rx) = SerialConfig::<_, _, DefaultMapping>::new(
+            periph.e_usci_a0,
+            BitOrder::LsbFirst,
+            BitCount::EightBits,
+            StopBits::OneStopBit,
+            // Launchpad UART-to-USB converter doesn't handle parity, so we don't use it
+            Parity::NoParity,
+            Loopback::NoLoop,
+            9600,
+        )
+        .use_aclk(&aclk)
+        .split(p1.pin4.to_alternate1(), p1.pin5.to_alternate1());
+
+        led.set_high().ok();
+        // embedded_io contains methods for writing with buffers
+        embedded_io::Write::write_all(&mut tx, b"HELLO\n").ok();
+        loop {
+            // embedded_hal_nb contains non-blocking methods for writing single bytes
+            let ch: u8 = match block!(rx.read()) {
+                Ok(c) => c,
+                Err(RecvError::Parity) => b'!',
+                Err(RecvError::Overrun(_)) => b'}',
+                Err(RecvError::Framing) => b'?',
+            };
+            block!(tx.write(ch)).unwrap();
+        }
+    } else {
+        loop {}
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/echo_remapped.rs
+++ b/device-examples/msp430fr2522/examples/echo_remapped.rs
@@ -1,0 +1,109 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::OutputPin;
+use embedded_hal_nb::serial::{Read, Write};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pin_mapping::{DefaultMapping, RemappedMapping},
+    pmm::Pmm,
+    serial::*,
+    watchdog::Wdt,
+};
+
+use nb::block;
+#[cfg(debug_assertions)]
+use panic_msp430 as _;
+
+#[cfg(not(debug_assertions))]
+use panic_never as _;
+
+// Prints "HELLO" when started then echos on UART1
+// Serial settings are listed in the code
+#[entry]
+fn main() -> ! {
+    if let Some(periph) = msp430fr25x2::Peripherals::take() {
+        let mut fram = Fram::new(periph.frctl);
+        let _wdt = Wdt::constrain(periph.wdt_a);
+
+        let (_smclk, aclk, _delay) = ClockConfig::new(periph.cs)
+            .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+            .smclk_on(SmclkDiv::_2)
+            .aclk_refoclk()
+            .freeze(&mut fram);
+
+        let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+
+        let p1 = Batch::new(periph.p1).split(&pmm);
+        let p2 = Batch::new(periph.p2).split(&pmm);
+
+        let mut led = p1.pin0.to_output();
+        led.set_low().ok();
+
+        let mut e_usci_a0 = periph.e_usci_a0;
+
+        // FIRST: Default UART mapping (P1.4 TX / P1.5 RX)
+        {
+            let mut tx = SerialConfig::<_, _, DefaultMapping>::new(
+                e_usci_a0,
+                BitOrder::LsbFirst,
+                BitCount::EightBits,
+                StopBits::OneStopBit,
+                Parity::NoParity,
+                Loopback::NoLoop,
+                9600,
+            )
+            .use_aclk(&aclk)
+            .tx_only(p1.pin4.to_alternate1());
+
+            embedded_io::Write::write_all(&mut tx, b"HELLO DEFAULT\n").ok();
+        }
+
+        unsafe {
+            e_usci_a0 = msp430fr25x2::Peripherals::steal().e_usci_a0;
+        }
+
+        // SECOND: Remap UART to P5.2 TX / P5.1 RX
+        let serial = SerialConfig::<_, _, RemappedMapping>::new(
+            e_usci_a0,
+            BitOrder::LsbFirst,
+            BitCount::EightBits,
+            StopBits::OneStopBit,
+            Parity::NoParity,
+            Loopback::NoLoop,
+            9600,
+        )
+        .use_aclk(&aclk);
+
+        let (mut tx, mut rx) = serial.split(p2.pin0.to_alternate1(), p2.pin1.to_alternate1());
+
+        led.set_high().ok();
+
+        embedded_io::Write::write_all(&mut tx, b"HELLO REMAPPED\n").ok();
+
+        // Echo loop on remapped UART
+        loop {
+            let ch: u8 = match block!(rx.read()) {
+                Ok(c) => c,
+                Err(RecvError::Parity) => b'!',
+                Err(RecvError::Overrun(_)) => b'}',
+                Err(RecvError::Framing) => b'?',
+            };
+
+            block!(tx.write(ch)).ok();
+        }
+    } else {
+        loop {}
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/gpio.rs
+++ b/device-examples/msp430fr2522/examples/gpio.rs
@@ -1,0 +1,41 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{gpio::Batch, pmm::Pmm, watchdog::Wdt};
+use panic_msp430 as _;
+
+// Green onboard LED should go on when P2.3 button is pressed
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p2 = Batch::new(periph.p2)
+        .config_pin3(|p| p.pullup())
+        .split(&pmm);
+    let p1 = Batch::new(periph.p1)
+        .config_pin6(|p| p.to_output())
+        .split(&pmm);
+
+    let mut p2_3 = p2.pin3;
+    let mut p1_6 = p1.pin6;
+
+    loop {
+        if p2_3.is_high().unwrap() {
+            p1_6.set_low().ok();
+        } else {
+            p1_6.set_high().ok();
+        }
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/gpio_interrupts.rs
+++ b/device-examples/msp430fr2522/examples/gpio_interrupts.rs
@@ -1,0 +1,99 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+
+use critical_section::with;
+use msp430fr25x2::interrupt;
+
+use core::cell::RefCell;
+use embedded_hal::digital::*;
+use msp430::interrupt::{enable as enable_int, Mutex};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::{Batch, GpioVector, Output, Pin, Pin0, PxIV, P1, P2},
+    pmm::Pmm,
+    watchdog::{Wdt, WdtClkPeriods},
+};
+use nb::block;
+use panic_msp430 as _;
+
+static RED_LED: Mutex<RefCell<Option<Pin<P1, Pin0, Output>>>> = Mutex::new(RefCell::new(None));
+static P2IV: Mutex<RefCell<Option<PxIV<P2>>>> = Mutex::new(RefCell::new(None));
+
+// Red LED should blink 2 seconds on, 2 seconds off
+// Both green and red LEDs should blink when P2.3 LED is pressed
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let mut wdt = Wdt::constrain(periph.wdt_a).to_interval();
+
+    let (_smclk, aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_refoclk(MclkDiv::_1) // 32 kHz MCLK
+        .smclk_on(SmclkDiv::_2) // 16 kHz SMCLK
+        .aclk_vloclk()
+        .freeze(&mut Fram::new(periph.frctl));
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+    let p2 = Batch::new(periph.p2)
+        .config_pin3(|p| p.pullup())
+        .split(&pmm);
+
+    let red_led = p1.pin0.to_output();
+    // Onboard button with interrupt disabled
+    let mut button = p2.pin3;
+    // Some random pin with interrupt enabled. IFG will be set manually.
+    let mut pin = p2.pin7.pulldown();
+    let p2iv = p2.pxiv;
+
+    with(|cs| RED_LED.borrow_ref_mut(cs).replace(red_led));
+    with(|cs| P2IV.borrow_ref_mut(cs).replace(p2iv));
+
+    wdt.set_aclk(&aclk)
+        .enable_interrupts()
+        .set_interval_and_start(WdtClkPeriods::_32k);
+    pin.select_rising_edge_trigger().enable_interrupts();
+    button.select_falling_edge_trigger();
+
+    unsafe { enable_int() };
+
+    loop {
+        block!(button.wait_for_ifg()).ok();
+        pin.set_ifg();
+    }
+}
+
+#[interrupt]
+fn PORT2() {
+    with(|cs| {
+        let Some(ref mut red_led) = *RED_LED.borrow_ref_mut(cs) else {
+            return;
+        };
+        let Some(ref mut p2iv) = *P2IV.borrow_ref_mut(cs) else {
+            return;
+        };
+
+        if let GpioVector::Pin7Isr = p2iv.get_interrupt_vector() {
+            red_led.toggle().ok();
+        }
+    });
+}
+
+#[interrupt]
+fn WDT() {
+    with(|cs| {
+        RED_LED.borrow_ref_mut(cs).as_mut().map(|red_led| {
+            red_led.toggle().ok();
+        })
+    });
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/i2c_master.rs
+++ b/device-examples/msp430fr2522/examples/i2c_master.rs
@@ -1,0 +1,114 @@
+#![no_main]
+#![no_std]
+
+// An I2C master using the blocking interface.
+
+use embedded_hal::{
+    delay::DelayNs,
+    digital::{OutputPin, StatefulOutputPin},
+    i2c::{I2c, Operation},
+};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    i2c::{GlitchFilter, I2cConfig, I2cSingleMaster},
+    pin_mapping::DefaultMapping,
+    pmm::Pmm,
+    prelude::*,
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+    let mut red_led = p1.pin0.to_output();
+    let mut green_led = Batch::new(periph.p2).split(&pmm).pin0.to_output();
+
+    let scl = p1.pin3.pullup().to_alternate1(); // You may need stronger external pullup resistors
+    let sda = p1.pin2.pullup().to_alternate1();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let mut i2c: I2cSingleMaster<_, DefaultMapping> =
+        I2cConfig::new(periph.e_usci_b0, GlitchFilter::Max50ns)
+            .as_single_master()
+            .use_smclk(&smclk, 80) // 8MHz / 80 = 100kHz
+            .configure(scl, sda);
+
+    const SLAVE_ADDR: u8 = 0x68;
+
+    loop {
+        // Below are examples of the various I2C methods provided for writing to / reading from the bus.
+        // 7- and 10-bit addressing modes are controlled by passing the address as either a u8 or a u16.
+
+        let mut is_ok = true;
+        let send_buf = [(1 << 7) + (0b01 << 5), 0b11];
+
+        // Check if anything with this address is present on the bus by
+        // sending a zero-byte write and listening for an ACK.
+        if let Ok(is_present) = i2c.is_slave_present(SLAVE_ADDR) {
+            if !is_present {
+                is_ok = false;
+            }
+        }
+
+        // Blocking write. Write two bytes (length of buffer) to address 0x12.
+        // If a NACK is recieved the transmission is aborted.
+        let wr_res = i2c.write(SLAVE_ADDR, &send_buf);
+        if wr_res.is_err() {
+            is_ok = false;
+        }
+
+        // Blocking read. Read one byte from address 0x12.
+        // Each byte recieved is automatically ACKed, except for the last one which is NACKed.
+        let mut recv = [0];
+        let rd_res = i2c.read(SLAVE_ADDR, &mut recv);
+        if rd_res.is_err() {
+            is_ok = false;
+        }
+
+        // Do a write then a read within one transaction.
+        // Commonly used to read a specific register from the slave.
+        // There is no 'stop' between the write and read, only a repeated start.
+        let wr_rd_res = i2c.write_read(SLAVE_ADDR, &send_buf, &mut recv);
+        if wr_rd_res.is_err() {
+            is_ok = false;
+        }
+
+        // Do any arbitrary transaction. One initial start, a repeated
+        // start between operations of dissimilar types, and a stop at the end.
+        // This particular example is equivalent to the write_read call above.
+        let tr_res = i2c.transaction(
+            SLAVE_ADDR,
+            &mut [Operation::Write(&send_buf), Operation::Read(&mut recv)],
+        );
+        if tr_res.is_err() {
+            is_ok = false;
+        }
+
+        green_led.set_state(is_ok.into()).ok();
+        red_led.toggle().ok();
+        delay.delay_ms(1000);
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/info_memory.rs
+++ b/device-examples/msp430fr2522/examples/info_memory.rs
@@ -1,0 +1,51 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430::asm;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{gpio::Batch, pmm::Pmm, watchdog::Wdt};
+use panic_msp430 as _;
+
+// Use the non-volatile information memory to toggle the red onboard LED.
+// Resetting or power cycling the board toggles the red LED.
+
+#[entry]
+fn main() -> ! {
+    // Take peripherals
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    // Configure GPIO
+    let (pmm, mut nv_mem) = Pmm::new(periph.pmm, periph.sys);
+    let mut led = Batch::new(periph.p1).split(&pmm).pin0.to_output();
+
+    // Wait a little bit to 'debounce' any power cycles.
+    for _ in 0..100 {
+        asm::nop();
+    }
+
+    // The write method provides a mutable reference to the memory, automatically managing write protection.
+    nv_mem.write(|mem|
+        // Toggle the first byte between 1 and 0
+        mem[0] = (mem[0].wrapping_add(1)) & 1);
+
+    // Reads needn't worry about write protection, so can be done directly by indexing.
+    // Turn the LED on if 0
+    led.set_state((nv_mem[0] == 0).into()).ok();
+
+    // If you don't care about write protection then nv_mem.into_unprotected() will
+    // disable write protection and return the underlying array directly.
+
+    loop {
+        msp430::asm::nop();
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/lpm0.rs
+++ b/device-examples/msp430fr2522/examples/lpm0.rs
@@ -1,0 +1,91 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+#![feature(asm_experimental_arch)]
+
+// NOTE: This example relies on the new wake-cpu feature recently added to the msp430-rt crate to return the CPU to active mode
+// after the interrupt returns. This depends on Rust 1.88+. For a version compatible with the MSRV of this crate see lpm0_msrv.rs
+
+use critical_section::with;
+use msp430fr25x2::{interrupt, P2};
+
+use core::cell::RefCell;
+use embedded_hal::digital::*;
+use msp430::{
+    asm,
+    interrupt::{enable as enable_interrupts, Mutex},
+};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    gpio::{Batch, GpioVector, PxIV},
+    lpm::enter_lpm0,
+    pmm::Pmm,
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+static P2IV: Mutex<RefCell<Option<PxIV<P2>>>> = Mutex::new(RefCell::new(None));
+
+// P1.0 should toggle when P2.3 is pressed
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let _wdt = Wdt::constrain(periph.wdt_a);
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+
+    // Floating input pins consume a *huge* amount of power (relatively speaking).
+    // Set unused pins to outputs or enable their pull resistors.
+    let p1 = Batch::new(periph.p1)
+        .pulldown_all()
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+    let mut green_led = p1.pin0;
+
+    let p2 = Batch::new(periph.p2)
+        .pulldown_all()
+        .config_pin3(|p| p.pullup())
+        .split(&pmm);
+    let mut button = p2.pin3;
+    let p2iv = p2.pxiv;
+
+    with(|cs| {
+        P2IV.borrow_ref_mut(cs).replace(p2iv);
+    });
+
+    button.select_falling_edge_trigger().enable_interrupts();
+
+    unsafe { enable_interrupts() };
+
+    loop {
+        // Since no peripherals were configured to use SMCLK / ACLK we could just as well enter LPM3 / LPM4 here
+        enter_lpm0();
+        green_led.toggle().ok();
+
+        for _ in 0..15_000 {
+            // Debouncing
+            asm::nop();
+        }
+    }
+}
+
+// Interrupt handlers with the `wake_cpu` argument will set the MSP430 back to Active Mode after the interrupt completes.
+#[interrupt(wake_cpu)]
+fn PORT2() {
+    with(|cs| {
+        let Some(ref mut p2iv) = *P2IV.borrow_ref_mut(cs) else {
+            return;
+        };
+        if let GpioVector::Pin3Isr = p2iv.get_interrupt_vector() {
+            // Button pressed
+        }
+    });
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/lpm0_msrv.rs
+++ b/device-examples/msp430fr2522/examples/lpm0_msrv.rs
@@ -1,0 +1,97 @@
+#![no_main]
+#![no_std]
+#![feature(abi_msp430_interrupt)]
+
+// NOTE: Historically there was no way to return the CPU to active mode after entering a low power mode,
+// the MSP restores the CPU to active mode during an interrupt but turns it off afterwards.
+
+// A feature was recently added to msp430-rt to allow the CPU to return to active mode, but it depends on Rust 1.88.
+// For compatibility with the MSRV of this crate we showcase the old implementation here, with all work being done inside the interrupt.
+// For the more flexible new version, see lpm0.rs
+
+use critical_section::with;
+use msp430fr25x2::{interrupt, P1, P2};
+
+use core::cell::RefCell;
+use embedded_hal::digital::*;
+use msp430::{
+    asm,
+    interrupt::{enable as enable_interrupts, Mutex},
+};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    gpio::{Batch, GpioVector, Output, Pin, Pin0, PxIV},
+    lpm::enter_lpm0,
+    pmm::Pmm,
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+static P2IV: Mutex<RefCell<Option<PxIV<P2>>>> = Mutex::new(RefCell::new(None));
+static RED_LED: Mutex<RefCell<Option<Pin<P1, Pin0, Output>>>> = Mutex::new(RefCell::new(None));
+
+// P1.0 should toggle when P2.3 is pressed
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let _wdt = Wdt::constrain(periph.wdt_a);
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+
+    // Floating input pins consume a *huge* amount of power (relatively speaking).
+    // Set unused pins to outputs or enable their pull resistors.
+    let p1 = Batch::new(periph.p1)
+        .pulldown_all()
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+    let red_led = p1.pin0;
+
+    let p2 = Batch::new(periph.p2)
+        .pulldown_all()
+        .config_pin3(|p| p.pullup())
+        .split(&pmm);
+    let mut button = p2.pin3;
+    let p2iv = p2.pxiv;
+
+    with(|cs| {
+        P2IV.borrow_ref_mut(cs).replace(p2iv);
+        RED_LED.borrow_ref_mut(cs).replace(red_led);
+    });
+
+    button.select_falling_edge_trigger().enable_interrupts();
+
+    unsafe { enable_interrupts() };
+
+    // Since no peripherals were configured to use SMCLK / ACLK we could just as well enter LPM3 / LPM4 here
+    enter_lpm0();
+
+    loop {}
+}
+
+// The CPU will wake up to handle interrupts, but will be put back to sleep afterwards.
+#[interrupt]
+fn PORT2() {
+    with(|cs| {
+        let Some(ref mut p2iv) = *P2IV.borrow_ref_mut(cs) else {
+            return;
+        };
+        let Some(ref mut red_led) = *RED_LED.borrow_ref_mut(cs) else {
+            return;
+        };
+        if let GpioVector::Pin3Isr = p2iv.get_interrupt_vector() {
+            red_led.toggle().ok();
+            for _ in 0..15_000 {
+                // Debouncing
+                asm::nop();
+            }
+        }
+    });
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/pwm.rs
+++ b/device-examples/msp430fr2522/examples/pwm.rs
@@ -1,0 +1,49 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::pwm::SetDutyCycle;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pmm::Pmm,
+    pwm::{PwmParts3, TimerConfig},
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+// P6.4 LED should be bright, P6.3 LED should be dim
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+
+    let (smclk, _aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let pwm = PwmParts3::new(periph.ta0, TimerConfig::smclk(&smclk), 5000);
+    let mut pwm4 = pwm.pwm1.init(p1.pin4.to_output().to_alternate2());
+    let mut pwm5 = pwm.pwm2.init(p1.pin5.to_output().to_alternate2());
+
+    pwm4.set_duty_cycle(100).unwrap();
+    pwm5.set_duty_cycle(3795).unwrap();
+
+    loop {}
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/rtc.rs
+++ b/device-examples/msp430fr2522/examples/rtc.rs
@@ -1,0 +1,65 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pmm::Pmm,
+    rtc::{Rtc, RtcDiv},
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+// Red LED blinks 2 seconds on, 2 off
+// Pressing P2.3 button toggles red LED
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1)
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+    let p2 = Batch::new(periph.p2)
+        .config_pin3(|p| p.pullup())
+        .split(&pmm);
+    let mut led = p1.pin0;
+    let mut button = p2.pin3;
+
+    let (_smclk, _aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_refoclk(MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut Fram::new(periph.frctl));
+
+    let mut rtc = Rtc::new(periph.rtc).use_vloclk();
+    rtc.set_clk_div(RtcDiv::_10);
+
+    button.select_falling_edge_trigger();
+    led.set_high().ok();
+
+    loop {
+        // 2 seconds
+        rtc.start(2000);
+        while let Err(nb::Error::WouldBlock) = rtc.wait() {
+            if button.wait_for_ifg().is_ok() {
+                led.toggle().ok();
+                rtc.pause();
+            }
+        }
+        led.toggle().ok();
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/spi_bus.rs
+++ b/device-examples/msp430fr2522/examples/spi_bus.rs
@@ -1,0 +1,78 @@
+#![no_main]
+#![no_std]
+
+// This example uses the SpiBus embedded-hal interface, with a software controlled CS pin.
+
+use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::MODE_0};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pin_mapping::RemappedMapping,
+    pmm::Pmm,
+    spi::{Spi, SpiConfig},
+    watchdog::Wdt,
+};
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+    let p2 = Batch::new(periph.p2).split(&pmm);
+    let mosi = p2.pin0.to_alternate1();
+    let miso = p2.pin1.to_alternate1();
+    let sck = p1.pin6.to_alternate1();
+    let mut cs = p1.pin3.to_output();
+    cs.set_high().ok();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    // In single master mode SCK and MOSI are always outputs.
+    // Multi-master mode allows another master to control whether this device's SCK
+    // and MOSI pins are outputs or high impedance via the STE pin.
+    let mut spi: Spi<_, RemappedMapping> = SpiConfig::new(periph.e_usci_a0, MODE_0, true)
+        .to_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
+        .single_master_bus(miso, mosi, sck);
+
+    loop {
+        // Blocking interface available through embedded-hal trait
+        use embedded_hal::spi::SpiBus;
+
+        // Perform the following transaction:
+        // Send: 0x12, 0x00,    0x00,    0x34,    0x56,
+        // Recv: N/A,  recv[0], recv[1], recv[2], N/A
+        let mut recv = [0; 3];
+        cs.set_low().ok();
+
+        // These methods do return errors, but because we haven't used the non-blocking
+        // API (from embedded-hal-nb) or interrupts the Rx buffer should never overrun because
+        // the blocking interface automatically reads after every write.
+        spi.write(&[0x12]).unwrap();
+        spi.read(&mut recv[0..2]).unwrap();
+        spi.transfer(&mut recv[2..], &[0x34, 0x56]).unwrap();
+
+        spi.flush().unwrap();
+        cs.set_high().ok();
+
+        delay.delay_ms(1000);
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/spi_nb.rs
+++ b/device-examples/msp430fr2522/examples/spi_nb.rs
@@ -1,0 +1,79 @@
+#![no_main]
+#![no_std]
+
+// This example uses the non-blocking interface from embedded-hal-nb, with a software controlled CS pin.
+
+use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::MODE_0};
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pin_mapping::RemappedMapping,
+    pmm::Pmm,
+    spi::{Spi, SpiConfig},
+    watchdog::Wdt,
+};
+use nb::block;
+use panic_msp430 as _;
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    let _wdt = Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1).split(&pmm);
+    let p2 = Batch::new(periph.p2).split(&pmm);
+    let mosi = p2.pin0.to_alternate1();
+    let miso = p2.pin1.to_alternate1();
+    let sck = p1.pin6.to_alternate1();
+    let mut cs = p1.pin3.to_output();
+    cs.set_high().ok();
+
+    let (smclk, _aclk, mut delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_8MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let mut spi: Spi<_, RemappedMapping> = SpiConfig::new(periph.e_usci_a0, MODE_0, true)
+        .to_master_using_smclk(&smclk, 16) // 8MHz / 16 = 500kHz
+        .single_master_bus(miso, mosi, sck);
+
+    loop {
+        // Non-blocking interface available through embedded-hal-nb
+        use embedded_hal_nb::spi::FullDuplex;
+
+        cs.set_low().ok();
+
+        // Blocking send. Sends out data on the MOSI line
+        // Sending is infallible, besides `nb::WouldBlock` when the bus is busy.
+        block!(spi.write(0b10101010)).unwrap();
+
+        // Writing on MOSI also shifts in data on MISO - read from the hardware buffer with `.read()`.
+        // Every successful `.write()` call should be followed by a `.read()`.
+        // You should handle errors here rather than unwrapping
+        let _ = block!(spi.read()).unwrap();
+
+        // This concludes the first byte of an SPI transaction.
+
+        // Multi-byte transactions are performed by calling the methods repeatedly:
+        block!(spi.write(0xFF)).unwrap();
+        let _ = block!(spi.read()).unwrap();
+
+        cs.set_high().ok();
+
+        delay.delay_ms(1000);
+    }
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/timer.rs
+++ b/device-examples/msp430fr2522/examples/timer.rs
@@ -1,0 +1,71 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{
+    clock::{ClockConfig, DcoclkFreqSel, MclkDiv, SmclkDiv},
+    fram::Fram,
+    gpio::Batch,
+    pin_mapping::PinMap,
+    pmm::Pmm,
+    timer::{CapCmp, SubTimer, Timer, TimerConfig, TimerDiv, TimerExDiv, TimerParts3, TimerPeriph},
+    watchdog::Wdt,
+};
+use nb::block;
+use panic_msp430 as _;
+
+// 0.5 second on, 0.5 second off
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    let mut fram = Fram::new(periph.frctl);
+    Wdt::constrain(periph.wdt_a);
+
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+    let p1 = Batch::new(periph.p1)
+        .config_pin0(|p| p.to_output())
+        .split(&pmm);
+    let mut p1_0 = p1.pin0;
+
+    let (_smclk, aclk, _delay) = ClockConfig::new(periph.cs)
+        .mclk_dcoclk(DcoclkFreqSel::_1MHz, MclkDiv::_1)
+        .smclk_on(SmclkDiv::_1)
+        .aclk_vloclk()
+        .freeze(&mut fram);
+
+    let parts = TimerParts3::new(
+        periph.ta0,
+        TimerConfig::aclk(&aclk).clk_div(TimerDiv::_2, TimerExDiv::_5),
+    );
+    let mut timer = parts.timer;
+    let mut subtimer = parts.subtimer2;
+
+    set_time(&mut timer, &mut subtimer, 500);
+    loop {
+        block!(subtimer.wait()).unwrap();
+        p1_0.set_high().unwrap();
+        // first 0.5 s of timer countdown expires while subtimer expires, so this should only block
+        // for 0.5 s
+        block!(timer.wait()).unwrap();
+        p1_0.set_low().unwrap();
+    }
+}
+
+fn set_time<T: TimerPeriph<M> + CapCmp<C>, C, M: PinMap>(
+    timer: &mut Timer<T, M>,
+    subtimer: &mut SubTimer<T, C>,
+    delay: u16,
+) {
+    timer.start(delay + delay);
+    subtimer.set_count(delay);
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/examples/watchdog.rs
+++ b/device-examples/msp430fr2522/examples/watchdog.rs
@@ -1,0 +1,33 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::digital::*;
+use msp430_rt::entry;
+use msp430fr2x5x_hal::{gpio::Batch, pmm::Pmm};
+use panic_msp430 as _;
+
+// The LED on P1.0 should flash rapidly
+
+#[entry]
+fn main() -> ! {
+    let periph = msp430fr25x2::Peripherals::take().unwrap();
+
+    // DON'T pause the watchdog
+    //let _wdt = Wdt::constrain(periph.WDT_A);
+    let (pmm, _) = Pmm::new(periph.pmm, periph.sys);
+
+    let mut red_led = Batch::new(periph.p1).split(&pmm).pin0.to_output();
+
+    red_led.toggle().ok();
+
+    // The watchdog will reset program execution after a few ms
+    loop {}
+}
+
+// The compiler will emit calls to the abort() compiler intrinsic if debug assertions are
+// enabled (default for dev profile). MSP430 does not actually have meaningful abort() support
+// so for now, we create our own in each application where debug assertions are present.
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!();
+}

--- a/device-examples/msp430fr2522/memory.x
+++ b/device-examples/msp430fr2522/memory.x
@@ -1,0 +1,14 @@
+MEMORY
+{
+  /* These values are correct for the msp430fr2522 device. You will have to
+     update accordingly for other devices. */
+  RAM : ORIGIN = 0x2000, LENGTH = 0x800
+  ROM : ORIGIN = 0xE300, LENGTH = 0x1C80
+  VECTORS : ORIGIN = 0xFF88, LENGTH = 0x78
+}
+
+/* Stack begins at the end of RAM:
+   _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* TODO: Code (and data?) above 64kB mark, which is supported even without
+   using MSP430X mode. */

--- a/device-examples/msp430fr2522/mspdebug.gdb
+++ b/device-examples/msp430fr2522/mspdebug.gdb
@@ -1,0 +1,9 @@
+target remote :2000
+
+set print asm-demangle on
+
+break panic
+break main
+
+load
+monitor reset

--- a/device-examples/msp430fr2522/run.bat
+++ b/device-examples/msp430fr2522/run.bat
@@ -1,0 +1,14 @@
+@REM echo off
+set arg1=%1
+@REM mspdebug --allow-fw-update tilib "prog %arg1%"
+@REM mspdebug --allow-fw-update tilib "run"
+
+@REM mspdebug --allow-fw-update tilib
+@REM prog %arg1%
+@REM run
+
+echo prog %arg1% > temp_commands.txt
+echo run >> temp_commands.txt
+
+mspdebug --allow-fw-update tilib < temp_commands.txt
+del temp_commands.txt

--- a/device-examples/msp430fr2522/run.sh
+++ b/device-examples/msp430fr2522/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+mspdebug --allow-fw-update tilib "prog $1 & run"

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -51,7 +51,7 @@ msp430 = "0.4.0"
 msp430fr2355 = { version = "0.6", features = ["rt", "critical-section"], optional = true }
 msp430fr2433 = { version = "0.2", features = ["rt", "critical-section"], optional = true }
 msp430fr247x = { version = "0.3.1", features = ["rt", "critical-section"], optional = true }
-msp430fr25x2 = { version = "0.3.1", features = ["rt", "critical-section"], optional = true }
+msp430fr25x2 = { version = "0.3.2", features = ["rt", "critical-section"], optional = true }
 nb = "1.1"
 void = { version = "1.0.2", default-features = false, optional = true }
 embedded-hal-02 = { package = 'embedded-hal', version = "0.2.7", features = ["unproven"], optional = true }

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -23,10 +23,13 @@ msp430fr2153 = ["2x5x"]           # 16kB FRAM
 msp430fr2433 = ["dep:msp430fr2433", "eusci_modclk", "adc", "adcpctl", "eusci_b", "info_mem"]
 msp430fr2475 = ["247x"]           # 6kB RAM
 msp430fr2476 = ["247x"]           # 8kB RAM
+msp430fr2512 = ["25x2"]           # 2kB RAM up to 8 self-capacitive and 16 mutual-capacitive sensors
+msp430fr2522 = ["25x2"]           # 2kB RAM up to 4 self-capacitive or mutual-capacitive sensors
 
 # Derived features. Do not provide these.
 2x5x = ["dep:msp430fr2355", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "ecomp", "eusci_b", "vloclk_source"]
 247x = ["dep:msp430fr247x", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "ecomp", "eusci_b", "vloclk_source"]
+25x2 = ["dep:msp430fr25x2", "eusci_aclk", "info_mem", "enhanced_ref", "adc12bit", "eusci_b", "vloclk_source"]
 eusci_aclk = [] # eUSCI peripherals can source from ACLK
 eusci_modclk = [] # eUSCI peripherals can source from MODCLK
 adc12bit = ["adc"]
@@ -48,6 +51,7 @@ msp430 = "0.4.0"
 msp430fr2355 = { version = "0.6", features = ["rt", "critical-section"], optional = true }
 msp430fr2433 = { version = "0.2", features = ["rt", "critical-section"], optional = true }
 msp430fr247x = { version = "0.3.1", features = ["rt", "critical-section"], optional = true }
+msp430fr25x2 = { version = "0.3.1", features = ["rt", "critical-section"], optional = true }
 nb = "1.1"
 void = { version = "1.0.2", default-features = false, optional = true }
 embedded-hal-02 = { package = 'embedded-hal', version = "0.2.7", features = ["unproven"], optional = true }

--- a/hal/src/device_specific.rs
+++ b/hal/src/device_specific.rs
@@ -16,4 +16,9 @@ pub mod device;
 #[path = "device_specific/fr247x.rs"]
 pub mod device;
 
+// MSP430FR25x2
+#[cfg(feature = "25x2")]
+#[path = "device_specific/fr25x2.rs"]
+pub mod device;
+
 pub use device::*;

--- a/hal/src/device_specific/fr25x2.rs
+++ b/hal/src/device_specific/fr25x2.rs
@@ -1,0 +1,472 @@
+pub use msp430fr25x2 as pac;
+
+/// PAC with standardised peripheral names. For the FR25x2 this is just the PAC.
+pub use msp430fr25x2 as _pac;
+
+/*         GPIO          */
+pub mod gpio {
+    // Make PAC GPIO available as a re-export
+    pub use crate::pac::{P1, P2};
+
+    use crate::gpio::*;
+    use crate::hw_traits::gpio::gpio_impl;
+
+    // Define alternate pin transitions
+
+    // P1 alternate 1
+    impl<PIN: PinNum, DIR> ToAlternate1 for Pin<P1, PIN, DIR> {}
+    // P1 alternate 2
+    impl<DIR> ToAlternate2 for Pin<P1, Pin1, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P1, Pin2, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P1, Pin3, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P1, Pin4, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P1, Pin5, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P1, Pin6, DIR> {}
+    // P1 alternate 3
+    impl<PIN: PinNum, DIR> ToAlternate3 for Pin<P1, PIN, DIR> {}
+
+    // P2 alternate 1
+    impl<DIR> ToAlternate1 for Pin<P2, Pin0, DIR> {}
+    impl<DIR> ToAlternate1 for Pin<P2, Pin1, DIR> {}
+    impl<DIR> ToAlternate1 for Pin<P2, Pin2, DIR> {}
+    impl<DIR> ToAlternate1 for Pin<P2, Pin3, DIR> {}
+    impl<DIR> ToAlternate1 for Pin<P2, Pin4, DIR> {}
+    impl<DIR> ToAlternate1 for Pin<P2, Pin5, DIR> {}
+    impl<DIR> ToAlternate1 for Pin<P2, Pin6, DIR> {}
+    // P2 alternate 2
+    impl<DIR> ToAlternate2 for Pin<P2, Pin0, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P2, Pin1, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P2, Pin2, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P2, Pin3, DIR> {}
+    impl<DIR> ToAlternate2 for Pin<P2, Pin4, DIR> {}
+
+    // GPIO port impls, PAC register methods, and marking ports as interrupt-capable
+    gpio_impl!(p1: P1 => p1in, p1out, p1dir, p1ren, p1selc, p1sel0, p1sel1, [p1ies, p1ie, p1ifg, p1iv]);
+    gpio_impl!(p2: P2 => p2in, p2out, p2dir, p2ren, p2selc, p2sel0, p2sel1, [p2ies, p2ie, p2ifg, p2iv]);
+}
+
+/* ADC */
+mod adc {
+    use crate::{adc::*, gpio::*};
+
+    impl_adc_channel_pin!(P1, Pin0, Alternate3 => 0);
+    impl_adc_channel_pin!(P1, Pin1, Alternate3 => 1);
+    impl_adc_channel_pin!(P1, Pin2, Alternate3 => 2);
+    impl_adc_channel_pin!(P1, Pin3, Alternate3 => 3);
+    impl_adc_channel_pin!(P2, Pin2, Alternate3 => 4);
+    impl_adc_channel_pin!(P2, Pin3, Alternate3 => 5);
+    impl_adc_channel_pin!(P2, Pin4, Alternate3 => 6);
+    impl_adc_channel_pin!(P2, Pin5, Alternate3 => 7);
+}
+
+/* Backup Memory */
+/// Size of the Backup Memory segment on this device, in bytes
+pub const BAK_MEM_SIZE: usize = 32;
+
+/* Capture */
+mod capture {
+    use crate::{capture::CapturePeriph, gpio::*, pac::*};
+
+    impl CapturePeriph for Ta0 {
+        type Gpio0 = ();
+        type Gpio1 = Pin<P1, Pin4, Alternate2<Input<Floating>>>;
+        type Gpio2 = Pin<P1, Pin5, Alternate2<Input<Floating>>>;
+        type Gpio3 = ();
+        type Gpio4 = ();
+        type Gpio5 = ();
+        type Gpio6 = ();
+    }
+
+    impl CapturePeriph for Ta1 {
+        type Gpio0 = ();
+        type Gpio1 = Pin<P2, Pin2, Alternate1<Input<Floating>>>;
+        type Gpio2 = Pin<P2, Pin3, Alternate1<Input<Floating>>>;
+        type Gpio3 = ();
+        type Gpio4 = ();
+        type Gpio5 = ();
+        type Gpio6 = ();
+    }
+}
+
+/* Clocks */
+/// MODCLK frequency
+pub const MODCLK_FREQ_HZ: u32 = 5_000_000;
+
+/* eUSCI */
+mod eusci {
+    use crate::{
+        hw_traits::{eusci::*, Steal},
+        pac::*,
+    };
+
+    eusci_steal_impl!(EUsciA0);
+    eusci_steal_impl!(EUsciB0);
+}
+
+/* I2C */
+mod i2c {
+    use crate::{
+        gpio::*,
+        hw_traits::eusci::*,
+        i2c::{impl_i2c_pin, I2cUsci},
+        pac::*,
+        pin_mapping::*,
+    };
+
+    eusci_i2c_impl!(
+        EUsciB0,
+        ucb0ctlw0,
+        ucb0ctlw1,
+        ucb0brw,
+        ucb0statw,
+        ucb0tbcnt,
+        ucb0rxbuf,
+        ucb0txbuf,
+        ucb0i2coa0,
+        ucb0i2coa1,
+        ucb0i2coa2,
+        ucb0i2coa3,
+        ucb0addrx,
+        ucb0addmask,
+        ucb0i2csa,
+        ucb0ie,
+        ucb0ifg,
+        ucb0iv,
+        crate::pac::e_usci_b0::ucb0ifg::R,
+    );
+
+    /// I2C SCL pin for eUSCI B0 (default mapping)
+    pub struct UsciB0SCLPinDefault;
+    impl_i2c_pin!(UsciB0SCLPinDefault, P1, Pin3);
+
+    /// I2C SCL pin for eUSCI B0 (remapped mapping)
+    pub struct UsciB0SCLPinRemapped;
+    impl_i2c_pin!(UsciB0SCLPinRemapped, P2, Pin6);
+
+    /// I2C SDA pin for eUSCI B0 (default mapping)
+    pub struct UsciB0SDAPinDefault;
+    impl_i2c_pin!(UsciB0SDAPinDefault, P1, Pin2);
+
+    /// I2C SDA pin for eUSCI B0 (remapped mapping)
+    pub struct UsciB0SDAPinRemapped;
+    impl_i2c_pin!(UsciB0SDAPinRemapped, P2, Pin5);
+
+    /// UCLKI pin for eUSCI B0. Used as an external clock source. (default mapping)
+    pub struct UsciB0UCLKIPinDefault;
+    impl_i2c_pin!(UsciB0UCLKIPinDefault, P1, Pin1);
+
+    /// UCLKI pin for eUSCI B0. Used as an external clock source. (remapped mapping)
+    pub struct UsciB0UCLKIPinRemapped;
+    impl_i2c_pin!(UsciB0UCLKIPinRemapped, P2, Pin4);
+
+    impl I2cUsci<DefaultMapping> for EUsciB0 {
+        type ClockPin = UsciB0SCLPinDefault;
+        type DataPin = UsciB0SDAPinDefault;
+        type ExternalClockPin = UsciB0UCLKIPinDefault;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg2().write(|w| w.uscibrmp().clear_bit());
+        }
+    }
+    impl I2cUsci<RemappedMapping> for EUsciB0 {
+        type ClockPin = UsciB0SCLPinRemapped;
+        type DataPin = UsciB0SDAPinRemapped;
+        type ExternalClockPin = UsciB0UCLKIPinRemapped;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg2().write(|w| w.uscibrmp().set_bit());
+        }
+    }
+}
+
+/* Information Memory */
+/// Size of the Information Memory segment on this device, in bytes
+pub const INFO_MEM_SIZE: usize = 512;
+
+/* PWM */
+mod pwm {
+    use crate::{gpio::*, pac::*, pwm::*};
+
+    // TA0
+    impl PwmPeriph<CCR1> for Ta0 {
+        type Gpio = Pin<P1, Pin4, Alternate2<Output>>;
+        const ALT: Alt = Alt::Alt2;
+    }
+    impl PwmPeriph<CCR2> for Ta0 {
+        type Gpio = Pin<P1, Pin5, Alternate2<Output>>;
+        const ALT: Alt = Alt::Alt2;
+    }
+
+    // TA1
+    impl PwmPeriph<CCR1> for Ta1 {
+        type Gpio = Pin<P2, Pin2, Alternate1<Output>>;
+        const ALT: Alt = Alt::Alt1;
+    }
+    impl PwmPeriph<CCR2> for Ta1 {
+        type Gpio = Pin<P2, Pin3, Alternate1<Output>>;
+        const ALT: Alt = Alt::Alt1;
+    }
+}
+
+/* Serial */
+mod serial {
+    use crate::{gpio::*, hw_traits::eusci::*, pac::*, pin_mapping::*, serial::*};
+
+    eusci_uart_impl!(
+        EUsciA0,
+        uca0ctlw0,
+        uca0ctlw1,
+        uca0brw,
+        uca0mctlw,
+        uca0statw,
+        uca0rxbuf,
+        uca0txbuf,
+        uca0ie,
+        uca0ifg,
+        uca0iv,
+        crate::pac::e_usci_a0::uca0statw::R
+    );
+
+    impl SerialUsci<DefaultMapping> for EUsciA0 {
+        type ClockPin = UsciA0ClockPinDefault;
+        type TxPin = UsciA0TxPinDefault;
+        type RxPin = UsciA0RxPinDefault;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg3().write(|w| w.usciarmp().clear_bit());
+        }
+    }
+    impl SerialUsci<RemappedMapping> for EUsciA0 {
+        type ClockPin = UsciA0ClockPinRemapped;
+        type TxPin = UsciA0TxPinRemapped;
+        type RxPin = UsciA0RxPinRemapped;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg3().write(|w| w.usciarmp().set_bit());
+        }
+    }
+
+    /// UCLK pin for E_USCI_A0 (default mapping)
+    pub struct UsciA0ClockPinDefault;
+    impl_serial_pin!(UsciA0ClockPinDefault, P1, Pin6);
+
+    /// UCLK pin for E_USCI_A0 (remapped mapping)
+    pub struct UsciA0ClockPinRemapped;
+    impl_serial_pin!(UsciA0ClockPinRemapped, P1, Pin6);
+
+    /// Tx pin for E_USCI_A0 (default mapping)
+    pub struct UsciA0TxPinDefault;
+    impl_serial_pin!(UsciA0TxPinDefault, P1, Pin4);
+
+    /// Tx pin for E_USCI_A0 (remapped mapping)
+    pub struct UsciA0TxPinRemapped;
+    impl_serial_pin!(UsciA0TxPinRemapped, P2, Pin0);
+
+    /// Rx pin for E_USCI_A0 (default mapping)
+    pub struct UsciA0RxPinDefault;
+    impl_serial_pin!(UsciA0RxPinDefault, P1, Pin5);
+
+    /// Rx pin for E_USCI_A0 (remapped mapping)
+    pub struct UsciA0RxPinRemapped;
+    impl_serial_pin!(UsciA0RxPinRemapped, P2, Pin1);
+}
+
+/* SPI */
+mod spi {
+    use crate::{gpio::*, hw_traits::eusci::*, pac::*, pin_mapping::*, spi::*};
+
+    eusci_spi_impl!(
+        EUsciA0,
+        uca0ctlw0_spi,
+        uca0brw,
+        uca0statw_spi,
+        uca0rxbuf,
+        uca0txbuf,
+        uca0ie_spi,
+        uca0ifg_spi,
+        uca0iv,
+        crate::pac::e_usci_a0::uca0statw_spi::R
+    );
+    eusci_spi_impl!(
+        EUsciB0,
+        ucb0ctlw0_spi,
+        ucb0brw,
+        ucb0statw_spi,
+        ucb0rxbuf,
+        ucb0txbuf,
+        ucb0ie_spi,
+        ucb0ifg_spi,
+        ucb0iv,
+        crate::pac::e_usci_b0::ucb0statw_spi::R
+    );
+
+    impl SpiUsci<DefaultMapping> for EUsciA0 {
+        type MISO = UsciA0MISOPinDefault;
+        type MOSI = UsciA0MOSIPinDefault;
+        type SCLK = UsciA0SCLKPinDefault;
+        type STE = UsciA0STEPinDefault;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg3().write(|w| w.usciarmp().clear_bit());
+        }
+    }
+
+    impl SpiUsci<RemappedMapping> for EUsciA0 {
+        type MISO = UsciA0MISOPinRemapped;
+        type MOSI = UsciA0MOSIPinRemapped;
+        type SCLK = UsciA0SCLKPinRemapped;
+        type STE = UsciA0STEPinRemapped;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg3().write(|w| w.usciarmp().set_bit());
+        }
+    }
+
+    impl SpiUsci<DefaultMapping> for EUsciB0 {
+        type MISO = UsciB0MISOPinDefault;
+        type MOSI = UsciB0MOSIPinDefault;
+        type SCLK = UsciB0SCLKPinDefault;
+        type STE = UsciB0STEPinDefault;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg2().write(|w| w.uscibrmp().clear_bit());
+        }
+    }
+
+    impl SpiUsci<RemappedMapping> for EUsciB0 {
+        type MISO = UsciB0MISOPinRemapped;
+        type MOSI = UsciB0MOSIPinRemapped;
+        type SCLK = UsciB0SCLKPinRemapped;
+        type STE = UsciB0STEPinRemapped;
+
+        fn configure_pin_mapping() {
+            let sys = unsafe { crate::_pac::Sys::steal() };
+            sys.syscfg2().write(|w| w.uscibrmp().set_bit());
+        }
+    }
+
+    /// SPI MISO pin for eUSCI A0 (P1.5) (default mapping)
+    pub struct UsciA0MISOPinDefault;
+    impl_spi_pin!(UsciA0MISOPinDefault, P1, Pin5);
+
+    /// SPI MISO pin for eUSCI A0 (P2.1) (remapped mapping)
+    pub struct UsciA0MISOPinRemapped;
+    impl_spi_pin!(UsciA0MISOPinRemapped, P2, Pin1);
+
+    /// SPI MOSI pin for eUSCI A0 (P1.4) (default mapping)
+    pub struct UsciA0MOSIPinDefault;
+    impl_spi_pin!(UsciA0MOSIPinDefault, P1, Pin4);
+
+    /// SPI MOSI pin for eUSCI A0 (P2.0) (remapped mapping)
+    pub struct UsciA0MOSIPinRemapped;
+    impl_spi_pin!(UsciA0MOSIPinRemapped, P2, Pin0);
+
+    /// SPI SCLK pin for eUSCI A0 (P1.6) (default mapping)
+    pub struct UsciA0SCLKPinDefault;
+    impl_spi_pin!(UsciA0SCLKPinDefault, P1, Pin6);
+
+    /// SPI SCLK pin for eUSCI A0 (P1.6) (remapped mapping)
+    pub struct UsciA0SCLKPinRemapped;
+    impl_spi_pin!(UsciA0SCLKPinRemapped, P1, Pin6);
+
+    /// SPI STE pin for eUSCI A0 (P1.7) (default mapping)
+    pub struct UsciA0STEPinDefault;
+    impl_spi_pin!(UsciA0STEPinDefault, P1, Pin7);
+
+    /// SPI STE pin for eUSCI A0 (P1.7) (remapped mapping)
+    pub struct UsciA0STEPinRemapped;
+    impl_spi_pin!(UsciA0STEPinRemapped, P1, Pin7);
+
+    /// SPI MISO pin for eUSCI B0 (P1.3) (default mapping)
+    pub struct UsciB0MISOPinDefault;
+    impl_spi_pin!(UsciB0MISOPinDefault, P1, Pin3);
+
+    /// SPI MISO pin for eUSCI B0 (P2.6) (remapped mapping)
+    pub struct UsciB0MISOPinRemapped;
+    impl_spi_pin!(UsciB0MISOPinRemapped, P2, Pin6);
+
+    /// SPI MOSI pin for eUSCI B0 (P1.2) (default mapping)
+    pub struct UsciB0MOSIPinDefault;
+    impl_spi_pin!(UsciB0MOSIPinDefault, P1, Pin2);
+
+    /// SPI MOSI pin for eUSCI B0 (P2.5) (remapped mapping)
+    pub struct UsciB0MOSIPinRemapped;
+    impl_spi_pin!(UsciB0MOSIPinRemapped, P2, Pin5);
+
+    /// SPI SCLK pin for eUSCI B0 (P1.1) (default mapping)
+    pub struct UsciB0SCLKPinDefault;
+    impl_spi_pin!(UsciB0SCLKPinDefault, P1, Pin1);
+
+    /// SPI SCLK pin for eUSCI B0 (P2.4) (remapped mapping)
+    pub struct UsciB0SCLKPinRemapped;
+    impl_spi_pin!(UsciB0SCLKPinRemapped, P2, Pin4);
+
+    /// SPI STE pin for eUSCI B0 (P1.0) (default mapping)
+    pub struct UsciB0STEPinDefault;
+    impl_spi_pin!(UsciB0STEPinDefault, P1, Pin0);
+
+    /// SPI STE pin for eUSCI B0 (P2.3) (remapped mapping)
+    pub struct UsciB0STEPinRemapped;
+    impl_spi_pin!(UsciB0STEPinRemapped, P2, Pin3);
+}
+
+/* Timer */
+mod timer {
+    use crate::{
+        gpio::*,
+        hw_traits::{timer_a::*, Steal},
+        pac::*,
+        timer::*,
+    };
+
+    timer_a_impl!(
+        Ta0,
+        ta0,
+        ta0ctl,
+        ta0ex0,
+        ta0iv,
+        ta0r,
+        taclr,
+        taifg,
+        taidex,
+        taie,
+        tassel,
+        [CCR0, ta0cctl0, ta0ccr0],
+        [CCR1, ta0cctl1, ta0ccr1],
+        [CCR2, ta0cctl2, ta0ccr2]
+    );
+
+    timer_a_impl!(
+        Ta1,
+        ta1,
+        ta1ctl,
+        ta1ex0,
+        ta1iv,
+        ta1r,
+        taclr,
+        taifg,
+        taidex,
+        taie,
+        tassel,
+        [CCR0, ta1cctl0, ta1ccr0],
+        [CCR1, ta1cctl1, ta1ccr1],
+        [CCR2, ta1cctl2, ta1ccr2]
+    );
+
+    impl TimerPeriph for Ta0 {
+        type Tbxclk = Pin<P1, Pin6, Alternate2<Input<Floating>>>;
+    }
+    impl CapCmpTimer3 for Ta0 {}
+
+    impl TimerPeriph for Ta1 {
+        type Tbxclk = Pin<P2, Pin4, Alternate1<Input<Floating>>>;
+    }
+    impl CapCmpTimer3 for Ta1 {}
+}

--- a/hal/src/hw_traits/eusci.rs
+++ b/hal/src/hw_traits/eusci.rs
@@ -488,7 +488,7 @@ macro_rules! eusci_spi_impl {
             }
 
             fn is_busy(&self) -> bool {
-                self.$ucxstatw().read().ucbusy().bit()
+                (self.$ucxstatw().read().bits() & 1) != 0
             }
         }
 
@@ -510,7 +510,7 @@ macro_rules! eusci_spi_impl {
 
             #[inline(always)]
             fn ucbusy(&self) -> bool {
-                self.ucbusy().bit()
+                (self.bits() & 1) != 0
             }
         }
     };

--- a/hal/src/hw_traits/eusci.rs
+++ b/hal/src/hw_traits/eusci.rs
@@ -488,7 +488,7 @@ macro_rules! eusci_spi_impl {
             }
 
             fn is_busy(&self) -> bool {
-                (self.$ucxstatw().read().bits() & 1) != 0
+                self.$ucxstatw().read().ucbusy().bit()
             }
         }
 
@@ -510,7 +510,7 @@ macro_rules! eusci_spi_impl {
 
             #[inline(always)]
             fn ucbusy(&self) -> bool {
-                (self.bits() & 1) != 0
+                self.ucbusy().bit()
             }
         }
     };

--- a/hal/src/lpm.rs
+++ b/hal/src/lpm.rs
@@ -191,8 +191,11 @@ fn enter_lpmx_5<MODE: WatchdogSelect>(mut wdt: Wdt<MODE>, svs: SvsState, regs: _
     regs.p1.p1sel0().reset();
     regs.p1.p1sel1().reset();
     /* P2 reset by 4.5 and 3.5 fns */
-    regs.p3.p3sel0().reset();
-    regs.p3.p3sel1().reset();
+    #[cfg(not(feature = "25x2"))]
+    {
+        regs.p3.p3sel0().reset();
+        regs.p3.p3sel1().reset();
+    }
 
     #[cfg(any(feature = "2x5x", feature = "247x"))]
     {

--- a/hal/src/pmm.rs
+++ b/hal/src/pmm.rs
@@ -53,8 +53,10 @@ impl Pmm {
             true => None,
             false => {
                 // Unlock PMM registers
-                self.0.pmmctl0().modify(|_,w| w.pmmpw().password() );
-                
+                self.0
+                    .pmmctl0()
+                    .modify(|_, w| unsafe { w.pmmpw().bits(0xA5) });
+
                 self.0.pmmctl2().write(|w| unsafe{ w
                     .bits(pmmctl2.bits()) 
                     .refvsel().bits(vref as u8)

--- a/hal/src/pmm.rs
+++ b/hal/src/pmm.rs
@@ -53,9 +53,7 @@ impl Pmm {
             true => None,
             false => {
                 // Unlock PMM registers
-                self.0
-                    .pmmctl0()
-                    .modify(|_, w| unsafe { w.pmmpw().bits(0xA5) });
+                self.0.pmmctl0().modify(|_, w| w.pmmpw().password() );
 
                 self.0.pmmctl2().write(|w| unsafe{ w
                     .bits(pmmctl2.bits()) 


### PR DESCRIPTION
These changes add support to [msp430fr25x2](https://www.ti.com/lit/ds/symlink/msp430fr2522.pdf?ts=1785815967147&ref_url=https%253A%252F%252Fwww.google.com%252F) devices.

