### PR TITLE
version: bumped 247x and 25x2 PACs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add support for the MSP430FR25x2 subfamily.
 - Add support for the MSP430FR247x subfamily.
 - Add support for pin remapping on certain peripherals on certain devices (like the FR247x subfamily). For devices that don't support pin remapping this should be invisible for the most part.
 - Add defmt support through `defmt` feature flag.

--- a/device-examples/msp430fr2476/Cargo.toml
+++ b/device-examples/msp430fr2476/Cargo.toml
@@ -12,7 +12,7 @@ panic-msp430 = "0.4.0"
 panic-never = "0.1.0"
 msp430 = { version = "0.4.1", features = ["critical-section-single-core"] }
 msp430-rt = "0.4.0"
-msp430fr247x = { version = "0.3.1", features = ["rt", "critical-section"]}
+msp430fr247x = { version = "0.3.3", features = ["rt", "critical-section"]}
 msp430fr2x5x-hal = { path = "../../hal", features = ["msp430fr2476"] }
 critical-section = "1.2.0"
 msp430-atomic = "0.1.5"

--- a/device-examples/msp430fr2522/Cargo.toml
+++ b/device-examples/msp430fr2522/Cargo.toml
@@ -12,7 +12,7 @@ panic-msp430 = "0.4.0"
 panic-never = "0.1.0"
 msp430 = { version = "0.4.1", features = ["critical-section-single-core"] }
 msp430-rt = "0.4.0"
-msp430fr25x2 = { version = "0.3.2", features = ["rt", "critical-section"]}
+msp430fr25x2 = { version = "0.3.3", features = ["rt", "critical-section"] }
 msp430fr2x5x-hal = { path = "../../hal", features = ["msp430fr2522"] }
 critical-section = "1.2.0"
 msp430-atomic = "0.1.5"

--- a/device-examples/msp430fr2522/memory.x
+++ b/device-examples/msp430fr2522/memory.x
@@ -4,7 +4,7 @@ MEMORY
      update accordingly for other devices. */
   RAM : ORIGIN = 0x2000, LENGTH = 0x800
   ROM : ORIGIN = 0xE300, LENGTH = 0x1C80
-  VECTORS : ORIGIN = 0xFF88, LENGTH = 0x78
+  VECTORS : ORIGIN = 0xFF80, LENGTH = 0x80
 }
 
 /* Stack begins at the end of RAM:

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -50,8 +50,8 @@ defmt = {version = "1.0", optional = true }
 msp430 = "0.4.0"
 msp430fr2355 = { version = "0.6", features = ["rt", "critical-section"], optional = true }
 msp430fr2433 = { version = "0.2", features = ["rt", "critical-section"], optional = true }
-msp430fr247x = { version = "0.3.1", features = ["rt", "critical-section"], optional = true }
-msp430fr25x2 = { version = "0.3.2", features = ["rt", "critical-section"], optional = true }
+msp430fr247x = { version = "0.3.3", features = ["rt", "critical-section"], optional = true }
+msp430fr25x2 = { version = "0.3.3", features = ["rt", "critical-section"], optional = true }
 nb = "1.1"
 void = { version = "1.0.2", default-features = false, optional = true }
 embedded-hal-02 = { package = 'embedded-hal', version = "0.2.7", features = ["unproven"], optional = true }


### PR DESCRIPTION
Bumped 247x and 25x2 PACs to 0.3.3 and fixed ./device_examples/msp430fr2522/memory.x

And updated CHANGELOG.md